### PR TITLE
fix: add Windows platform compatibility

### DIFF
--- a/README.ja.md
+++ b/README.ja.md
@@ -78,7 +78,8 @@ v0.3.x（tmux-first）は有効性を示しましたが、現実的な限界も�
 ```text
 ~/.cccc/
   daemon/
-    ccccd.sock
+    ccccd.addr.json   # daemon endpoint（クロスプラットフォーム；Windows は既定で TCP）
+    ccccd.sock        # Unix domain socket（プラットフォーム/設定によってのみ存在）
     ccccd.log
   groups/<group_id>/
     group.yaml
@@ -92,7 +93,7 @@ v0.3.x（tmux-first）は有効性を示しましたが、現実的な限界も�
 ## 要件
 
 - Python 3.9+
-- macOS / Linux（Windows は WSL 推奨）
+- macOS / Linux / Windows（Windows ネイティブは `headless` runner 推奨。PTY が必要なら WSL）
 - 対応する agent CLI を最低 1 つインストール（Claude/Codex/Droid/OpenCode/Copilot など）
 - Node.js は **Web UI 開発** のみで必要（ユーザーは同梱 UI を利用可能）
 

--- a/README.md
+++ b/README.md
@@ -78,7 +78,8 @@ Runtime layout (default):
 ```text
 ~/.cccc/
   daemon/
-    ccccd.sock
+    ccccd.addr.json   # daemon endpoint (cross-platform; TCP on Windows by default)
+    ccccd.sock        # Unix domain socket (only on some platforms/configs)
     ccccd.log
   groups/<group_id>/
     group.yaml
@@ -92,7 +93,7 @@ Runtime layout (default):
 ## Requirements
 
 - Python 3.9+
-- macOS / Linux (Windows via WSL recommended)
+- macOS / Linux / Windows (Windows native recommends `headless` runner; for PTY use WSL)
 - At least one supported agent runtime CLI installed (Claude/Codex/Droid/OpenCode/Copilot/…)
 - Node.js is only needed for **Web UI development** (end users get a bundled UI)
 
@@ -118,6 +119,34 @@ Note: at the moment, the latest stable on PyPI is still the legacy v0.3.x line. 
 git clone https://github.com/ChesterRa/cccc
 cd cccc
 pip install -e .
+```
+
+### Use uv (recommended, especially on Windows)
+
+Note: `uv` can download/select Python, create an isolated venv, and run without activation. `.venv/` and `.cccc/` are ignored by git.
+
+Windows (PowerShell):
+
+```powershell
+uv venv -p 3.11 .venv
+uv pip install -p .venv\Scripts\python.exe -e .
+uv run -p .venv\Scripts\python.exe --no-sync cccc --help
+```
+
+macOS / Linux:
+
+```bash
+uv venv -p 3.11 .venv
+uv pip install -p .venv/bin/python -e .
+uv run -p .venv/bin/python --no-sync cccc --help
+```
+
+Optional: isolate runtime home to this repo (instead of writing to `~/.cccc/`):
+
+```powershell
+$env:CCCC_HOME = (Join-Path $PWD '.cccc')
+uv run -p .venv\Scripts\python.exe --no-sync cccc daemon start
+uv run -p .venv\Scripts\python.exe --no-sync cccc web
 ```
 
 Web UI development (optional):

--- a/README.zh-CN.md
+++ b/README.zh-CN.md
@@ -78,7 +78,8 @@ v0.3.x（tmux-first）验证了“多 agent + 编排循环”是可行的，但�
 ```text
 ~/.cccc/
   daemon/
-    ccccd.sock
+    ccccd.addr.json   # daemon 端点（跨平台；Windows 默认 TCP）
+    ccccd.sock        # Unix domain socket（仅在部分平台/配置下存在）
     ccccd.log
   groups/<group_id>/
     group.yaml
@@ -92,7 +93,7 @@ v0.3.x（tmux-first）验证了“多 agent + 编排循环”是可行的，但�
 ## 运行要求
 
 - Python 3.9+
-- macOS / Linux（Windows 建议使用 WSL）
+- macOS / Linux / Windows（Windows 原生推荐 `headless` runner；若需要内嵌终端/PTY 体验建议使用 WSL）
 - 至少安装一个支持的 agent CLI（Claude/Codex/Droid/OpenCode/Copilot 等）
 - Node.js 仅用于 **Web UI 开发**（普通用户无需 Node，UI 已内置打包）
 
@@ -118,6 +119,39 @@ python -m pip install --index-url https://pypi.org/simple \
 git clone https://github.com/ChesterRa/cccc
 cd cccc
 pip install -e .
+```
+
+### 使用 uv 管理开发环境（推荐，尤其是 Windows）
+
+说明：`uv` 会为你选择/下载合适的 Python，并创建隔离的虚拟环境；仓库内的 `.venv/`、`.cccc/` 都在 `.gitignore` 中。
+
+Windows（PowerShell）：
+
+```powershell
+# 1) 创建虚拟环境（也可用 -p 3.12）
+uv venv -p 3.11 .venv
+
+# 2) 安装（editable）
+uv pip install -p .venv\Scripts\python.exe -e .
+
+# 3) 运行（不需要激活 venv）
+uv run -p .venv\Scripts\python.exe --no-sync cccc --help
+```
+
+macOS / Linux：
+
+```bash
+uv venv -p 3.11 .venv
+uv pip install -p .venv/bin/python -e .
+uv run -p .venv/bin/python --no-sync cccc --help
+```
+
+可选：将运行时目录隔离到当前仓库（避免写入默认的 `~/.cccc/`）：
+
+```powershell
+$env:CCCC_HOME = (Join-Path $PWD '.cccc')
+uv run -p .venv\Scripts\python.exe --no-sync cccc daemon start
+uv run -p .venv\Scripts\python.exe --no-sync cccc web
 ```
 
 Web UI 开发（可选）：
@@ -186,7 +220,7 @@ cccc setup --runtime <name>
 - 多 group 导航
 - Actor 管理（add/start/stop/relaunch）
 - Chat（@mentions + reply）
-- 每个 actor 的内嵌终端（PTY runner）
+- 每个 actor 的内嵌终端（PTY runner；Windows 原生推荐使用 `headless` 或 WSL）
 - Context + Automation settings
 - IM Bridge 配置
 - PROJECT.md 查看/编辑（repo root）

--- a/src/cccc/contracts/v1/event.py
+++ b/src/cccc/contracts/v1/event.py
@@ -77,6 +77,8 @@ class GroupSetActiveScopeData(BaseModel):
 
 class GroupStartData(BaseModel):
     started: List[str] = Field(default_factory=list)
+    # When PTY is unavailable (e.g., Windows), some actors may be forced to headless.
+    forced_headless: List[str] = Field(default_factory=list)
 
     model_config = ConfigDict(extra="forbid")
 
@@ -124,6 +126,8 @@ class ActorSetRoleData(BaseModel):
 class ActorLifecycleData(BaseModel):
     actor_id: str
     runner: Optional[str] = None  # pty or headless
+    # Effective runner used at runtime (e.g., PTY → headless fallback).
+    runner_effective: Optional[str] = None
 
     model_config = ConfigDict(extra="forbid")
 

--- a/src/cccc/daemon_main.py
+++ b/src/cccc/daemon_main.py
@@ -58,6 +58,7 @@ def main(argv: Optional[list[str]] = None) -> int:
                 print("ccccd: cleaning up stale state from crashed daemon")
                 try:
                     paths.sock_path.unlink(missing_ok=True)
+                    paths.addr_path.unlink(missing_ok=True)
                     paths.pid_path.unlink(missing_ok=True)
                 except Exception:
                     pass

--- a/src/cccc/runners/__init__.py
+++ b/src/cccc/runners/__init__.py
@@ -1,5 +1,11 @@
 from __future__ import annotations
 
-from . import headless, pty
+from . import headless
+
+try:
+    from . import pty
+except Exception:
+    # Windows (and some Python builds) lack POSIX PTY dependencies (pty/termios/fcntl).
+    from . import pty_stub as pty  # type: ignore
 
 __all__ = ["headless", "pty"]

--- a/src/cccc/runners/headless.py
+++ b/src/cccc/runners/headless.py
@@ -96,9 +96,10 @@ class HeadlessSession:
             self._status = "stopped"
             self._updated_at = utc_now_iso()
 
-        if self._on_exit is not None:
+        hook = self.on_exit
+        if hook is not None:
             try:
-                self.on_exit(self)
+                hook(self)
             except Exception:
                 pass
 

--- a/src/cccc/runners/pty.py
+++ b/src/cccc/runners/pty.py
@@ -18,6 +18,8 @@ from typing import Callable, Dict, Iterable, Optional, Tuple
 
 import termios
 
+PTY_SUPPORTED = True
+
 
 def _set_winsize(fd: int, *, cols: int, rows: int) -> None:
     try:

--- a/src/cccc/runners/pty_stub.py
+++ b/src/cccc/runners/pty_stub.py
@@ -1,0 +1,78 @@
+from __future__ import annotations
+
+import socket
+from dataclasses import dataclass
+from pathlib import Path
+from typing import Callable, Dict, Iterable, Optional, Tuple
+
+PTY_SUPPORTED = False
+
+
+@dataclass
+class PtySession:
+    group_id: str = ""
+    actor_id: str = ""
+    pid: int = 0
+
+
+class PtySupervisor:
+    def set_exit_hook(self, hook: Optional[Callable[[PtySession], None]]) -> None:
+        return None
+
+    def group_running(self, group_id: str) -> bool:
+        return False
+
+    def actor_running(self, group_id: str, actor_id: str) -> bool:
+        return False
+
+    def tail_output(self, *, group_id: str, actor_id: str, max_bytes: int = 2_000_000) -> bytes:
+        return b""
+
+    def clear_backlog(self, *, group_id: str, actor_id: str) -> bool:
+        return False
+
+    def start_actor(
+        self,
+        *,
+        group_id: str,
+        actor_id: str,
+        cwd: Path,
+        command: Iterable[str],
+        env: Dict[str, str],
+        max_backlog_bytes: int = 2_000_000,
+    ) -> PtySession:
+        raise RuntimeError("pty runner is not supported on this platform; use runner='headless'")
+
+    def stop_actor(self, *, group_id: str, actor_id: str) -> None:
+        return None
+
+    def stop_group(self, *, group_id: str) -> None:
+        return None
+
+    def stop_all(self) -> None:
+        return None
+
+    def attach(self, *, group_id: str, actor_id: str, sock: socket.socket) -> None:
+        raise RuntimeError("pty runner is not supported on this platform")
+
+    def bracketed_paste_enabled(self, *, group_id: str, actor_id: str) -> bool:
+        return False
+
+    def bracketed_paste_status(self, *, group_id: str, actor_id: str) -> Tuple[bool, Optional[float]]:
+        return (False, None)
+
+    def startup_times(self, *, group_id: str, actor_id: str) -> Tuple[Optional[float], Optional[float]]:
+        return (None, None)
+
+    def session_key(self, *, group_id: str, actor_id: str) -> Optional[str]:
+        return None
+
+    def resize(self, *, group_id: str, actor_id: str, cols: int, rows: int) -> None:
+        return None
+
+    def write_input(self, *, group_id: str, actor_id: str, data: bytes) -> bool:
+        return False
+
+
+SUPERVISOR = PtySupervisor()
+

--- a/src/cccc/util/file_lock.py
+++ b/src/cccc/util/file_lock.py
@@ -1,0 +1,101 @@
+from __future__ import annotations
+
+import os
+from pathlib import Path
+from typing import IO
+
+
+class LockUnavailableError(RuntimeError):
+    """Raised when a non-blocking lock cannot be acquired."""
+
+
+def _ensure_lock_region(f: IO[bytes]) -> None:
+    """Ensure the lock file has at least 1 byte so region locks work on Windows."""
+    try:
+        f.seek(0, os.SEEK_END)
+        if f.tell() <= 0:
+            f.write(b"\0")
+            f.flush()
+        f.seek(0)
+    except Exception:
+        # Best-effort: even if this fails, locking may still work depending on platform.
+        pass
+
+
+def _lock_posix(fd: int, *, blocking: bool) -> None:
+    import fcntl  # POSIX only
+
+    flags = fcntl.LOCK_EX
+    if not blocking:
+        flags |= fcntl.LOCK_NB
+    fcntl.flock(fd, flags)
+
+
+def _unlock_posix(fd: int) -> None:
+    import fcntl  # POSIX only
+
+    fcntl.flock(fd, fcntl.LOCK_UN)
+
+
+def _lock_windows(fd: int, *, blocking: bool) -> None:
+    import msvcrt  # Windows only
+
+    mode = msvcrt.LK_LOCK if blocking else msvcrt.LK_NBLCK
+    msvcrt.locking(fd, mode, 1)
+
+
+def _unlock_windows(fd: int) -> None:
+    import msvcrt  # Windows only
+
+    msvcrt.locking(fd, msvcrt.LK_UNLCK, 1)
+
+
+def acquire_lockfile(path: Path, *, blocking: bool = True) -> IO[bytes]:
+    """Open + lock a lockfile. Keep the returned handle open to hold the lock."""
+    path.parent.mkdir(parents=True, exist_ok=True)
+    # Use a non-append mode so callers can update lock contents (pid, etc).
+    f = path.open("r+b") if path.exists() else path.open("w+b")
+    _ensure_lock_region(f)
+    try:
+        if os.name == "nt":
+            _lock_windows(f.fileno(), blocking=blocking)
+        else:
+            _lock_posix(f.fileno(), blocking=blocking)
+    except BlockingIOError as e:
+        try:
+            f.close()
+        except Exception:
+            pass
+        if not blocking:
+            raise LockUnavailableError(str(e)) from e
+        raise
+    except OSError as e:
+        try:
+            f.close()
+        except Exception:
+            pass
+        if not blocking:
+            raise LockUnavailableError(str(e)) from e
+        raise
+    except Exception:
+        try:
+            f.close()
+        except Exception:
+            pass
+        raise
+    return f
+
+
+def release_lockfile(f: IO[bytes]) -> None:
+    """Release a lockfile acquired via acquire_lockfile (best-effort)."""
+    try:
+        if os.name == "nt":
+            _unlock_windows(f.fileno())
+        else:
+            _unlock_posix(f.fileno())
+    except Exception:
+        pass
+    try:
+        f.close()
+    except Exception:
+        pass

--- a/start.ps1
+++ b/start.ps1
@@ -1,0 +1,77 @@
+param(
+  [string]$Python = '3.11',
+  [string]$WebHost = '127.0.0.1',
+  [int]$WebPort = 8848,
+  [ValidateSet('info', 'debug', 'warning', 'error', 'critical')]
+  [string]$WebLogLevel = 'info',
+  [switch]$Reload,
+  [switch]$LocalHome,
+  [switch]$SkipInstall
+)
+
+$ErrorActionPreference = 'Stop'
+Set-StrictMode -Version Latest
+
+$repoRoot = Split-Path -Parent $MyInvocation.MyCommand.Path
+Set-Location $repoRoot
+
+function Require-Command([string]$Name) {
+  if (-not (Get-Command $Name -ErrorAction SilentlyContinue)) {
+    throw "Missing required command: $Name. Install it first (https://github.com/astral-sh/uv)."
+  }
+}
+
+Require-Command 'uv'
+
+$venvDir = Join-Path $repoRoot '.venv'
+$venvPython = Join-Path $venvDir 'Scripts\python.exe'
+
+if (-not (Test-Path $venvPython)) {
+  Write-Host "[start] Creating venv (.venv) with Python $Python..."
+  uv venv -p $Python $venvDir | Out-Host
+}
+
+if (-not $SkipInstall) {
+  Write-Host "[start] Installing (editable) with uv..."
+  uv pip install -p $venvPython -e . | Out-Host
+}
+
+# Optional: isolate runtime home to this repo (kept in .gitignore).
+if ($LocalHome) {
+  $env:CCCC_HOME = (Join-Path $repoRoot '.cccc')
+}
+
+$env:CCCC_WEB_HOST = $WebHost
+$env:CCCC_WEB_PORT = "$WebPort"
+$env:CCCC_WEB_LOG_LEVEL = $WebLogLevel
+if ($Reload) { $env:CCCC_WEB_RELOAD = '1' } else { if ($env:CCCC_WEB_RELOAD) { Remove-Item Env:CCCC_WEB_RELOAD -ErrorAction SilentlyContinue } }
+
+# Port preflight (helpful when a stale web process is already running).
+try {
+  $listeners = Get-NetTCPConnection -State Listen -LocalPort $WebPort -ErrorAction SilentlyContinue
+  if ($listeners) {
+    try {
+      $ping = Invoke-RestMethod -TimeoutSec 2 -Uri ("http://{0}:{1}/api/v1/ping" -f $WebHost, $WebPort)
+      if ($ping -and $ping.ok -eq $true) {
+        Write-Host ("[start] Already running: http://{0}:{1}/ui/" -f $WebHost, $WebPort)
+        if ($LocalHome -and $ping.result -and $ping.result.home) {
+          Write-Host ("[start] Server home: {0}" -f $ping.result.home)
+        }
+        return
+      }
+    } catch {
+      # Ignore; fall through and report the port conflict.
+    }
+
+    $pids = ($listeners | Select-Object -ExpandProperty OwningProcess -Unique) -join ','
+    throw "Port $WebPort is already in use (PID(s): $pids). Use -WebPort <port> or stop the existing process."
+  }
+} catch {
+  # Get-NetTCPConnection may not exist on some minimal environments; ignore.
+}
+
+Write-Host "[start] Starting CCCC (daemon + web)..."
+Write-Host ("[start] UI: http://{0}:{1}/ui/" -f $WebHost, $WebPort)
+Write-Host "[start] Press Ctrl+C to stop."
+
+uv run -p $venvPython --no-sync cccc


### PR DESCRIPTION
## Summary
- Add PTY stub module for Windows (pty not supported on Windows)
- Add cross-platform file locking utility (fcntl on POSIX, msvcrt on Windows)
- Update daemon server with Windows-compatible IPC handling
- Update runner initialization with platform detection
- Add PowerShell start script (`start.ps1`) for Windows users
- Update documentation with Windows installation notes

## Test Plan
- [ ] Test on Windows: run `python -m cccc` or `./start.ps1`
- [ ] Verify daemon starts without PTY-related errors
- [ ] Verify file locking works correctly on Windows
- [ ] Test on Linux/macOS to ensure no regressions

Co-Authored-By: Claude <noreply@anthropic.com>