### PR TITLE
feat: add support for Feishu and DingTalk platforms in IM bridge

### DIFF
--- a/README.ja.md
+++ b/README.ja.md
@@ -201,7 +201,7 @@ scope ルート（repo root）に `PROJECT.md` を置き、プロジェクトの
 
 ---
 
-## IM Bridge（Telegram / Slack / Discord）
+## IM Bridge（Telegram / Slack / Discord / Feishu / DingTalk）
 
 Working Group を IM にブリッジできます：
 

--- a/README.md
+++ b/README.md
@@ -231,7 +231,7 @@ Place `PROJECT.md` at the scope root (repo root). Treat it as the project consti
 
 ---
 
-## IM Bridge (Telegram / Slack / Discord)
+## IM Bridge (Telegram / Slack / Discord / Feishu / DingTalk)
 
 CCCC can bridge a working group to an IM platform.
 

--- a/README.zh-CN.md
+++ b/README.zh-CN.md
@@ -236,7 +236,7 @@ cccc setup --runtime <name>
 
 ---
 
-## IM Bridge（Telegram / Slack / Discord）
+## IM Bridge（Telegram / Slack / Discord / 飞书 / 钉钉）
 
 CCCC 支持把 working group 桥接到 IM 平台：
 

--- a/src/cccc/ports/im/__init__.py
+++ b/src/cccc/ports/im/__init__.py
@@ -1,7 +1,8 @@
 """
 CCCC IM Bridge Port
 
-Provides IM platform integration (Telegram, Slack, Discord) for CCCC groups.
+Provides IM platform integration for CCCC groups.
+Supported platforms: Telegram, Slack, Discord, Feishu, DingTalk.
 Each group can bind to one IM bot for remote control and notifications.
 
 Architecture:

--- a/src/cccc/ports/im/__main__.py
+++ b/src/cccc/ports/im/__main__.py
@@ -14,8 +14,15 @@ from .bridge import start_bridge
 
 def main() -> int:
     if len(sys.argv) < 2:
-        print("Usage: python -m cccc.ports.im.bridge <group_id> [platform]")
-        print("  platform: telegram (default), slack, discord")
+        print("Usage: python -m cccc.ports.im <group_id> [platform]")
+        print("  platform: telegram (default), slack, discord, feishu, dingtalk")
+        print("")
+        print("Environment variables:")
+        print("  Telegram: TELEGRAM_BOT_TOKEN")
+        print("  Slack:    SLACK_BOT_TOKEN, SLACK_APP_TOKEN (optional)")
+        print("  Discord:  DISCORD_BOT_TOKEN")
+        print("  Feishu:   FEISHU_APP_ID, FEISHU_APP_SECRET")
+        print("  DingTalk: DINGTALK_APP_KEY, DINGTALK_APP_SECRET, DINGTALK_ROBOT_CODE (optional)")
         return 1
 
     group_id = sys.argv[1]

--- a/src/cccc/ports/im/adapters/__init__.py
+++ b/src/cccc/ports/im/adapters/__init__.py
@@ -5,11 +5,22 @@ Each adapter handles platform-specific communication:
 - Telegram: Long-poll getUpdates
 - Slack: Socket Mode + Web API
 - Discord: Gateway
+- Feishu: WebSocket + REST API
+- DingTalk: Stream mode + REST API
 """
 
 from .base import IMAdapter
 from .telegram import TelegramAdapter
 from .slack import SlackAdapter
 from .discord import DiscordAdapter
+from .feishu import FeishuAdapter
+from .dingtalk import DingTalkAdapter
 
-__all__ = ["IMAdapter", "TelegramAdapter", "SlackAdapter", "DiscordAdapter"]
+__all__ = [
+    "IMAdapter",
+    "TelegramAdapter",
+    "SlackAdapter",
+    "DiscordAdapter",
+    "FeishuAdapter",
+    "DingTalkAdapter",
+]

--- a/src/cccc/ports/im/adapters/dingtalk.py
+++ b/src/cccc/ports/im/adapters/dingtalk.py
@@ -1,0 +1,847 @@
+"""
+DingTalk adapter for CCCC IM Bridge.
+
+Uses DingTalk Open API with Stream mode for real-time messaging.
+Reference: https://open.dingtalk.com/document/
+
+Features:
+- access_token auto-refresh (2h expiry)
+- Stream mode event subscription (long connection)
+- Rate limiting (20 msg/sec total)
+- File upload/download support
+"""
+
+from __future__ import annotations
+
+import hashlib
+import hmac
+import base64
+import json
+import threading
+import time
+import urllib.error
+import urllib.parse
+import urllib.request
+import uuid
+from pathlib import Path
+from typing import Any, Dict, List, Optional
+
+from .base import IMAdapter
+
+# DingTalk API limits
+DINGTALK_MAX_MESSAGE_LENGTH = 4096
+DEFAULT_MAX_CHARS = 4096
+DEFAULT_MAX_LINES = 64
+
+# API base URLs
+DINGTALK_API_OLD = "https://oapi.dingtalk.com"
+DINGTALK_API_NEW = "https://api.dingtalk.com"
+
+
+class RateLimiter:
+    """
+    Rate limiter for DingTalk API.
+
+    DingTalk limits:
+    - Total: ~20 msg/sec
+    - Same chat: ~5 msg/sec
+    """
+
+    def __init__(self, max_per_second: float = 5.0):
+        self.min_interval = 1.0 / max_per_second
+        self.last_send: Dict[str, float] = {}
+        self.lock = threading.Lock()
+
+    def acquire(self, chat_id: str) -> float:
+        """
+        Check if we can send to this chat.
+        Returns wait time in seconds (0 if can send immediately).
+        """
+        with self.lock:
+            now = time.time()
+            last = self.last_send.get(chat_id, 0)
+            elapsed = now - last
+
+            if elapsed >= self.min_interval:
+                self.last_send[chat_id] = now
+                return 0.0
+            else:
+                return self.min_interval - elapsed
+
+    def wait_and_acquire(self, chat_id: str) -> None:
+        """Wait if needed, then acquire."""
+        wait_time = self.acquire(chat_id)
+        if wait_time > 0:
+            time.sleep(wait_time)
+            self.acquire(chat_id)
+
+
+class DingTalkAdapter(IMAdapter):
+    """
+    DingTalk adapter using Stream mode for inbound and REST API for outbound.
+    """
+
+    platform = "dingtalk"
+
+    def __init__(
+        self,
+        app_key: str,
+        app_secret: str,
+        robot_code: str = "",
+        log_path: Optional[Path] = None,
+        max_chars: int = DEFAULT_MAX_CHARS,
+        max_lines: int = DEFAULT_MAX_LINES,
+    ):
+        self.app_key = app_key
+        self.app_secret = app_secret
+        self.robot_code = robot_code or app_key  # Robot code defaults to app_key
+        self.log_path = log_path
+        self.max_chars = max_chars
+        self.max_lines = max_lines
+
+        # Token management
+        self._token: str = ""
+        self._token_expires: float = 0
+        self._token_lock = threading.Lock()
+
+        # Message queue (thread-safe)
+        self._message_queue: List[Dict[str, Any]] = []
+        self._queue_lock = threading.Lock()
+
+        # Rate limiter
+        self._rate_limiter = RateLimiter(max_per_second=5.0)
+
+        # Connection state
+        self._connected = False
+        self._stream_thread: Optional[threading.Thread] = None
+        self._stream_running = False
+
+        # Cache for conversation info
+        self._conversation_cache: Dict[str, str] = {}
+
+        # Cache for session webhooks (conversation_id -> (webhook_url, expires_at))
+        self._session_webhook_cache: Dict[str, tuple[str, float]] = {}
+
+    def _log(self, msg: str) -> None:
+        """Append to log file if configured."""
+        if self.log_path:
+            try:
+                self.log_path.parent.mkdir(parents=True, exist_ok=True)
+                with self.log_path.open("a", encoding="utf-8") as f:
+                    ts = time.strftime("%Y-%m-%d %H:%M:%S")
+                    f.write(f"{ts} [dingtalk] {msg}\n")
+            except Exception:
+                pass
+
+    def _get_token(self) -> str:
+        """Get valid access_token, refreshing if needed."""
+        with self._token_lock:
+            now = time.time()
+            # Refresh 5 minutes before expiry
+            if self._token and now < self._token_expires - 300:
+                return self._token
+
+            # Refresh token
+            if self._refresh_token():
+                return self._token
+            return ""
+
+    def _refresh_token(self) -> bool:
+        """
+        Refresh access_token.
+        Token expires in 2 hours (7200 seconds).
+        """
+        url = f"{DINGTALK_API_OLD}/gettoken"
+        params = {
+            "appkey": self.app_key,
+            "appsecret": self.app_secret,
+        }
+        query = urllib.parse.urlencode(params)
+        full_url = f"{url}?{query}"
+
+        req = urllib.request.Request(full_url, method="GET")
+        req.add_header("Accept", "application/json")
+
+        try:
+            with urllib.request.urlopen(req, timeout=10) as resp:
+                body = resp.read().decode("utf-8", errors="replace")
+                result = json.loads(body)
+
+                if result.get("errcode") == 0:
+                    self._token = result.get("access_token", "")
+                    expire = int(result.get("expires_in", 7200))
+                    self._token_expires = time.time() + expire
+                    self._log(f"[token] Refreshed, expires in {expire}s")
+                    return True
+                else:
+                    self._log(f"[token] Failed: {result.get('errmsg', 'unknown')}")
+                    return False
+        except Exception as e:
+            self._log(f"[token] Error: {e}")
+            return False
+
+    def _api_old(
+        self,
+        method: str,
+        endpoint: str,
+        body: Optional[Dict[str, Any]] = None,
+        timeout: int = 15,
+    ) -> Dict[str, Any]:
+        """
+        Call DingTalk old API (oapi.dingtalk.com).
+
+        Used for: token, some legacy APIs
+        """
+        token = self._get_token()
+        if not token and "gettoken" not in endpoint:
+            return {"errcode": -1, "errmsg": "No valid token"}
+
+        url = f"{DINGTALK_API_OLD}{endpoint}"
+
+        if method == "GET":
+            if body:
+                query = urllib.parse.urlencode(body)
+                url = f"{url}?{query}"
+            if token and "access_token" not in url:
+                sep = "&" if "?" in url else "?"
+                url = f"{url}{sep}access_token={token}"
+            data = None
+        else:
+            if token and "access_token" not in url:
+                sep = "&" if "?" in url else "?"
+                url = f"{url}{sep}access_token={token}"
+            data = json.dumps(body or {}, ensure_ascii=False).encode("utf-8") if body else None
+
+        req = urllib.request.Request(url, data=data, method=method)
+        req.add_header("Content-Type", "application/json; charset=utf-8")
+        req.add_header("Accept", "application/json")
+
+        try:
+            with urllib.request.urlopen(req, timeout=timeout) as resp:
+                result_body = resp.read().decode("utf-8", errors="replace")
+                return json.loads(result_body)
+        except urllib.error.HTTPError as e:
+            http_status = e.code
+            err_text = ""
+            try:
+                err_text = e.read().decode("utf-8", "ignore")[:300]
+            except Exception:
+                pass
+            self._log(f"[api_old] {method} {endpoint}: HTTP {http_status} - {err_text}")
+            return {"errcode": http_status, "errmsg": str(e), "error": err_text}
+        except Exception as e:
+            self._log(f"[api_old] {method} {endpoint}: {e}")
+            return {"errcode": -1, "errmsg": str(e)}
+
+    def _api_new(
+        self,
+        method: str,
+        endpoint: str,
+        body: Optional[Dict[str, Any]] = None,
+        timeout: int = 15,
+    ) -> Dict[str, Any]:
+        """
+        Call DingTalk new API (api.dingtalk.com).
+
+        Used for: robot messages, conversations, files
+        """
+        token = self._get_token()
+        if not token:
+            return {"code": -1, "message": "No valid token"}
+
+        url = f"{DINGTALK_API_NEW}{endpoint}"
+
+        if method == "GET" and body:
+            query = urllib.parse.urlencode(body)
+            url = f"{url}?{query}"
+            data = None
+        else:
+            data = json.dumps(body or {}, ensure_ascii=False).encode("utf-8") if body else None
+
+        req = urllib.request.Request(url, data=data, method=method)
+        req.add_header("x-acs-dingtalk-access-token", token)
+        req.add_header("Content-Type", "application/json; charset=utf-8")
+        req.add_header("Accept", "application/json")
+
+        try:
+            with urllib.request.urlopen(req, timeout=timeout) as resp:
+                result_body = resp.read().decode("utf-8", errors="replace")
+                return json.loads(result_body)
+        except urllib.error.HTTPError as e:
+            http_status = e.code
+            err_text = ""
+            try:
+                err_text = e.read().decode("utf-8", "ignore")[:300]
+            except Exception:
+                pass
+            self._log(f"[api_new] {method} {endpoint}: HTTP {http_status} - {err_text}")
+            return {"code": http_status, "message": str(e), "error": err_text}
+        except Exception as e:
+            self._log(f"[api_new] {method} {endpoint}: {e}")
+            return {"code": -1, "message": str(e)}
+
+    def connect(self) -> bool:
+        """
+        Initialize connection to DingTalk.
+
+        1. Verify credentials by getting token
+        2. Start Stream mode listener (if available)
+        """
+        # Get initial token
+        if not self._refresh_token():
+            self._log("[connect] Failed to get token")
+            return False
+
+        # Start Stream listener for events
+        self._start_stream_listener()
+
+        self._connected = True
+        self._log(f"[connect] Connected with app_key={self.app_key[:8]}...")
+        return True
+
+    def _start_stream_listener(self) -> None:
+        """
+        Start Stream mode listener using DingTalk official SDK.
+
+        Uses dingtalk-stream SDK for reliable long connection.
+        """
+        if self._stream_thread and self._stream_thread.is_alive():
+            return
+
+        self._stream_running = True
+
+        def stream_loop():
+            """Stream event loop using official DingTalk SDK."""
+            self._log("[stream] Event listener starting...")
+
+            # Try to import official SDK
+            try:
+                import dingtalk_stream
+                from dingtalk_stream import AckMessage
+            except ImportError:
+                self._log("[stream] dingtalk-stream not installed")
+                self._log("[stream] Install with: pip install dingtalk-stream")
+                while self._stream_running:
+                    time.sleep(5.0)
+                return
+
+            # Create handler class that references self
+            adapter = self
+
+            class CCCCChatbotHandler(dingtalk_stream.ChatbotHandler):
+                """Handler for incoming chatbot messages."""
+
+                async def process(self, callback: dingtalk_stream.CallbackMessage):
+                    """Process incoming message from DingTalk."""
+                    try:
+                        adapter._log("[stream] Received message callback")
+
+                        # callback.data is a dict, not an object
+                        data = callback.data
+                        adapter._log(f"[stream] Message data: {data}")
+
+                        # Build event dict for _enqueue_message
+                        event = {
+                            "msgtype": data.get('msgtype', 'text'),
+                            "conversationId": data.get('conversationId', ''),
+                            "conversationType": data.get('conversationType', ''),
+                            "senderId": data.get('senderId', ''),
+                            "senderStaffId": data.get('senderStaffId', ''),
+                            "senderNick": data.get('senderNick', ''),
+                            "msgId": data.get('msgId', ''),
+                            "isAdmin": data.get('isAdmin', False),
+                            "chatbotUserId": data.get('chatbotUserId', ''),
+                            "conversationTitle": data.get('conversationTitle', ''),
+                            "sessionWebhook": data.get('sessionWebhook', ''),
+                            "sessionWebhookExpiredTime": data.get('sessionWebhookExpiredTime', 0),
+                        }
+
+                        # Extract text content (text is also a dict)
+                        text_data = data.get('text', {})
+                        if text_data:
+                            event["text"] = {"content": text_data.get('content', '')}
+                            adapter._log(f"[stream] Text: {event['text']}")
+
+                        # Enqueue the message
+                        adapter._enqueue_message(event)
+                        adapter._log("[stream] Message enqueued successfully")
+
+                        return AckMessage.STATUS_OK, 'OK'
+
+                    except Exception as e:
+                        adapter._log(f"[stream] Handler error: {e}")
+                        import traceback
+                        adapter._log(f"[stream] Traceback: {traceback.format_exc()}")
+                        return AckMessage.STATUS_SYSTEM_EXCEPTION, str(e)
+
+            try:
+                # Create credential and client
+                credential = dingtalk_stream.Credential(self.app_key, self.app_secret)
+                self._stream_client = dingtalk_stream.DingTalkStreamClient(credential)
+
+                # Register chatbot handler
+                self._stream_client.register_callback_handler(
+                    dingtalk_stream.chatbot.ChatbotMessage.TOPIC,
+                    CCCCChatbotHandler()
+                )
+
+                self._log("[stream] Starting DingTalk Stream client...")
+
+                # start_forever() is blocking
+                self._stream_client.start_forever()
+
+            except Exception as e:
+                self._log(f"[stream] SDK error: {e}")
+                import traceback
+                self._log(f"[stream] Traceback: {traceback.format_exc()}")
+
+            self._log("[stream] Event listener stopped")
+
+        self._stream_thread = threading.Thread(target=stream_loop, daemon=True)
+        self._stream_thread.start()
+
+    def disconnect(self) -> None:
+        """Disconnect from DingTalk."""
+        self._connected = False
+        self._stream_running = False
+
+        # Stop SDK client if running
+        if hasattr(self, '_stream_client') and self._stream_client:
+            try:
+                # DingTalk SDK doesn't have a clean stop method
+                # The thread will exit when _stream_running is False
+                pass
+            except Exception:
+                pass
+
+        if self._stream_thread:
+            self._stream_thread.join(timeout=2.0)
+        self._log("[disconnect] Disconnected")
+
+    def poll(self) -> List[Dict[str, Any]]:
+        """
+        Poll for new messages.
+
+        Returns queued messages from Stream listener.
+        """
+        if not self._connected:
+            return []
+
+        with self._queue_lock:
+            messages = self._message_queue.copy()
+            self._message_queue.clear()
+
+        return messages
+
+    def _enqueue_message(self, event: Dict[str, Any]) -> None:
+        """
+        Process incoming event and enqueue normalized message.
+
+        Called by Stream listener or webhook handler.
+        """
+        try:
+            # DingTalk event structure varies by type
+            # Robot callback format
+            msg_type = event.get("msgtype", "")
+            conversation_id = event.get("conversationId", "")
+            sender_id = event.get("senderStaffId", "") or event.get("senderId", "")
+            sender_nick = event.get("senderNick", "user")
+            msg_id = event.get("msgId", "")
+
+            # Extract text based on message type
+            if msg_type == "text":
+                content = event.get("text", {})
+                text = content.get("content", "")
+            elif msg_type == "richText":
+                text = self._extract_rich_text(event.get("richText", []))
+            elif msg_type == "picture":
+                text = "[image]"
+            elif msg_type == "file":
+                text = f"[file: {event.get('fileName', 'unknown')}]"
+            else:
+                text = f"[{msg_type}]"
+
+            if not text.strip():
+                return
+
+            # Build attachments list
+            attachments: List[Dict[str, Any]] = []
+            if msg_type == "picture":
+                attachments.append({
+                    "provider": "dingtalk",
+                    "kind": "image",
+                    "download_code": event.get("downloadCode", ""),
+                    "file_name": "image.png",
+                })
+            elif msg_type == "file":
+                attachments.append({
+                    "provider": "dingtalk",
+                    "kind": "file",
+                    "download_code": event.get("downloadCode", ""),
+                    "file_name": event.get("fileName", "file"),
+                })
+
+            # Determine chat type
+            conversation_type = event.get("conversationType", "")
+            if conversation_type == "1":
+                chat_type = "p2p"
+            elif conversation_type == "2":
+                chat_type = "group"
+            else:
+                chat_type = "unknown"
+
+            # Get chat title (use from event if available, else API)
+            chat_title = event.get("conversationTitle", "")
+            if not chat_title:
+                chat_title = self._get_conversation_title_cached(conversation_id)
+
+            # Cache sessionWebhook for this conversation (for replying)
+            session_webhook = event.get("sessionWebhook", "")
+            session_expires = event.get("sessionWebhookExpiredTime", 0)
+            if session_webhook and conversation_id:
+                # Convert ms to seconds
+                expires_at = session_expires / 1000.0 if session_expires > 1e10 else float(session_expires)
+                self._session_webhook_cache[conversation_id] = (session_webhook, expires_at)
+                self._log(f"[webhook] Cached: id={conversation_id}, expires_raw={session_expires}, expires_at={expires_at:.0f}")
+
+            # Normalize message
+            normalized = {
+                "chat_id": conversation_id,
+                "chat_title": chat_title,
+                "chat_type": chat_type,
+                "thread_id": 0,  # DingTalk doesn't have threading like this
+                "text": text,
+                "attachments": attachments,
+                "from_user": sender_nick or sender_id,
+                "message_id": msg_id,
+                # Keep sessionWebhook for potential reply use
+                "_session_webhook": session_webhook,
+            }
+
+            with self._queue_lock:
+                self._message_queue.append(normalized)
+
+        except Exception as e:
+            self._log(f"[enqueue] Error: {e}")
+
+    def _extract_rich_text(self, rich_text: List[Dict[str, Any]]) -> str:
+        """Extract plain text from rich text content."""
+        texts = []
+        try:
+            for item in rich_text:
+                if item.get("text"):
+                    texts.append(item["text"])
+        except Exception:
+            pass
+        return " ".join(texts)
+
+    def _get_conversation_title_cached(self, conversation_id: str) -> str:
+        """Get conversation title with caching."""
+        if conversation_id in self._conversation_cache:
+            return self._conversation_cache[conversation_id]
+
+        title = self.get_chat_title(conversation_id)
+        self._conversation_cache[conversation_id] = title
+        return title
+
+    def _send_via_webhook(self, webhook_url: str, text: str) -> bool:
+        """Send message via sessionWebhook (most reliable for groups)."""
+        body = {
+            "msgtype": "text",
+            "text": {
+                "content": text
+            }
+        }
+        data = json.dumps(body, ensure_ascii=False).encode('utf-8')
+
+        req = urllib.request.Request(webhook_url, data=data, method="POST")
+        req.add_header("Content-Type", "application/json; charset=utf-8")
+
+        try:
+            with urllib.request.urlopen(req, timeout=15) as resp:
+                result = json.loads(resp.read().decode('utf-8', errors='replace'))
+                if result.get('errcode') == 0:
+                    self._log(f"[webhook] Sent successfully")
+                    return True
+                self._log(f"[webhook] Failed: {result}")
+                return False
+        except Exception as e:
+            self._log(f"[webhook] Error: {e}")
+            return False
+
+    def send_message(self, chat_id: str, text: str, thread_id: Optional[int] = None) -> bool:
+        """
+        Send a text message to a conversation.
+
+        Args:
+            chat_id: DingTalk conversationId
+            text: Message text
+            thread_id: Unused (DingTalk doesn't support threading)
+        """
+        _ = thread_id  # DingTalk doesn't support message threading
+
+        if not text:
+            return True
+
+        if not self._connected:
+            return False
+
+        # Ensure message fits limit
+        safe_text = self._compose_safe(text)
+
+        # Rate limit
+        self._rate_limiter.wait_and_acquire(chat_id)
+
+        # Try sessionWebhook first (most reliable for group messages)
+        self._log(f"[send] chat_id={chat_id}, cache_keys={list(self._session_webhook_cache.keys())}")
+        if chat_id in self._session_webhook_cache:
+            webhook_url, expires_at = self._session_webhook_cache[chat_id]
+            current_time = time.time()
+            self._log(f"[send] Found in cache: expires_at={expires_at:.0f}, current={current_time:.0f}, delta={expires_at - current_time:.0f}s")
+            if current_time < expires_at:
+                self._log(f"[send] Using cached webhook for {chat_id[:20]}...")
+                if self._send_via_webhook(webhook_url, safe_text):
+                    return True
+                self._log("[send] Webhook failed, falling back to API...")
+            else:
+                # Webhook expired, remove from cache
+                del self._session_webhook_cache[chat_id]
+                self._log(f"[send] Webhook expired for {chat_id[:20]}...")
+        else:
+            self._log(f"[send] No cached webhook for {chat_id[:20]}...")
+
+        # Use robot message API
+        body: Dict[str, Any] = {
+            "robotCode": self.robot_code,
+            "msgKey": "sampleText",
+            "msgParam": json.dumps({"content": safe_text}, ensure_ascii=False),
+        }
+
+        # Determine if group or 1:1
+        if chat_id.startswith("cid"):
+            # Group conversation
+            body["openConversationId"] = chat_id
+            endpoint = "/v1.0/robot/groupMessages/send"
+        else:
+            # 1:1 conversation - need user ID
+            body["userIds"] = [chat_id]
+            endpoint = "/v1.0/robot/oToMessages/batchSend"
+
+        resp = self._api_new("POST", endpoint, body)
+
+        if resp.get("processQueryKey") or resp.get("sendResults"):
+            return True
+
+        # Try alternative API for older bots
+        if "code" in resp or "errcode" in resp:
+            return self._send_message_legacy(chat_id, safe_text)
+
+        self._log(f"[send] Failed to chat {chat_id}: {resp}")
+        return False
+
+    def _send_message_legacy(self, chat_id: str, text: str) -> bool:
+        """Send message using legacy API (for older bot types)."""
+        body = {
+            "chatid": chat_id,
+            "msg": {
+                "msgtype": "text",
+                "text": {
+                    "content": text,
+                },
+            },
+        }
+
+        resp = self._api_old("POST", "/chat/send", body)
+
+        if resp.get("errcode") == 0:
+            return True
+
+        self._log(f"[send_legacy] Failed: {resp.get('errmsg', 'unknown')}")
+        return False
+
+    def _compose_safe(self, text: str) -> str:
+        """Ensure message fits within DingTalk limits."""
+        summarized = self.summarize(text, self.max_chars, self.max_lines)
+
+        if len(summarized) > DINGTALK_MAX_MESSAGE_LENGTH:
+            summarized = summarized[: DINGTALK_MAX_MESSAGE_LENGTH - 1] + "..."
+
+        return summarized
+
+    def get_chat_title(self, chat_id: str) -> str:
+        """Get conversation title via API."""
+        # Try new API first
+        resp = self._api_new("GET", f"/v1.0/im/conversations/{chat_id}")
+
+        if resp.get("title"):
+            return resp["title"]
+
+        # Try legacy API
+        resp = self._api_old("GET", "/chat/get", {"chatid": chat_id})
+
+        if resp.get("errcode") == 0:
+            return resp.get("name", chat_id)
+
+        return chat_id
+
+    def download_attachment(self, attachment: Dict[str, Any]) -> bytes:
+        """Download an attachment from DingTalk."""
+        download_code = attachment.get("download_code", "")
+        if not download_code:
+            raise ValueError("Missing download_code")
+
+        token = self._get_token()
+        if not token:
+            raise ValueError("No valid token")
+
+        # Get download URL
+        resp = self._api_new("POST", "/v1.0/robot/messageFiles/download", {
+            "downloadCode": download_code,
+            "robotCode": self.robot_code,
+        })
+
+        download_url = resp.get("downloadUrl", "")
+        if not download_url:
+            raise ValueError(f"Failed to get download URL: {resp}")
+
+        # Download file
+        req = urllib.request.Request(download_url, method="GET")
+
+        try:
+            with urllib.request.urlopen(req, timeout=30) as r:
+                return r.read()
+        except Exception as e:
+            raise ValueError(f"Download failed: {e}")
+
+    def send_file(
+        self,
+        chat_id: str,
+        *,
+        file_path: Path,
+        filename: str,
+        caption: str = "",
+        thread_id: Optional[int] = None,
+    ) -> bool:
+        """Send a file to a conversation."""
+        _ = thread_id  # DingTalk doesn't support threading
+
+        if not self._connected:
+            return False
+
+        token = self._get_token()
+        if not token:
+            return False
+
+        # Rate limit
+        self._rate_limiter.wait_and_acquire(chat_id)
+
+        try:
+            raw = file_path.read_bytes()
+        except Exception as e:
+            self._log(f"[send_file] Read failed: {e}")
+            return False
+
+        # Step 1: Upload file to get media_id
+        boundary = "----cccc" + uuid.uuid4().hex
+        upload_url = f"{DINGTALK_API_OLD}/media/upload"
+        upload_url = f"{upload_url}?access_token={token}&type=file"
+
+        safe_fn = (filename or file_path.name or "file").replace("\\", "_").replace("/", "_")
+
+        # Build multipart form data
+        body = b""
+        body += (
+            f"--{boundary}\r\n"
+            f'Content-Disposition: form-data; name="media"; filename="{safe_fn}"\r\n'
+            f"Content-Type: application/octet-stream\r\n\r\n"
+        ).encode("utf-8")
+        body += raw
+        body += f"\r\n--{boundary}--\r\n".encode("utf-8")
+
+        req = urllib.request.Request(upload_url, data=body, method="POST")
+        req.add_header("Content-Type", f"multipart/form-data; boundary={boundary}")
+
+        try:
+            with urllib.request.urlopen(req, timeout=60) as resp:
+                result = json.loads(resp.read().decode("utf-8", errors="replace"))
+
+            if result.get("errcode") != 0:
+                self._log(f"[send_file] Upload failed: {result.get('errmsg', 'unknown')}")
+                return False
+
+            media_id = result.get("media_id", "")
+            if not media_id:
+                self._log("[send_file] No media_id in response")
+                return False
+
+        except Exception as e:
+            self._log(f"[send_file] Upload error: {e}")
+            return False
+
+        # Step 2: Send file message
+        msg_body: Dict[str, Any] = {
+            "chatid": chat_id,
+            "msg": {
+                "msgtype": "file",
+                "file": {
+                    "media_id": media_id,
+                },
+            },
+        }
+
+        resp = self._api_old("POST", "/chat/send", msg_body)
+
+        if resp.get("errcode") == 0:
+            # Send caption as separate message if provided
+            if caption:
+                self.send_message(chat_id, caption)
+            return True
+
+        self._log(f"[send_file] Send failed: {resp.get('errmsg', 'unknown')}")
+        return False
+
+    def format_outbound(self, by: str, to: List[str], text: str, is_system: bool = False) -> str:
+        """Format message for DingTalk display."""
+        formatted = super().format_outbound(by, to, text, is_system)
+        return self._compose_safe(formatted)
+
+    # ===== Webhook Event Handling =====
+
+    def handle_webhook_event(self, event: Dict[str, Any]) -> Optional[Dict[str, Any]]:
+        """
+        Handle incoming webhook event from DingTalk.
+
+        This method should be called by an external HTTP server
+        when receiving events from DingTalk webhook/callback.
+        """
+        self._enqueue_message(event)
+        return None
+
+    def verify_callback_signature(
+        self,
+        timestamp: str,
+        nonce: str,
+        signature: str,
+    ) -> bool:
+        """
+        Verify DingTalk callback signature.
+
+        Used for webhook callback security validation.
+        """
+        try:
+            # Sort and concatenate
+            sign_str = f"{timestamp}\n{nonce}\n{self.app_secret}"
+
+            # HMAC-SHA256
+            hmac_code = hmac.new(
+                self.app_secret.encode("utf-8"),
+                sign_str.encode("utf-8"),
+                hashlib.sha256,
+            ).digest()
+
+            # Base64 encode
+            computed = base64.b64encode(hmac_code).decode("utf-8")
+
+            return computed == signature
+        except Exception:
+            return False

--- a/src/cccc/ports/im/adapters/feishu.py
+++ b/src/cccc/ports/im/adapters/feishu.py
@@ -1,0 +1,754 @@
+"""
+Feishu (Lark) adapter for CCCC IM Bridge.
+
+Uses Feishu Open API with WebSocket long connection for real-time messaging.
+Reference: https://open.feishu.cn/document/
+
+Features:
+- tenant_access_token auto-refresh (2h expiry)
+- WebSocket event subscription (long connection)
+- Rate limiting (5 msg/sec per chat)
+- File upload/download support
+"""
+
+from __future__ import annotations
+
+import json
+import threading
+import time
+import urllib.error
+import urllib.parse
+import urllib.request
+import uuid
+from pathlib import Path
+from typing import Any, Dict, List, Optional
+
+from .base import IMAdapter
+
+# Feishu API limits
+FEISHU_MAX_MESSAGE_LENGTH = 4096
+DEFAULT_MAX_CHARS = 4096
+DEFAULT_MAX_LINES = 64
+
+# API base URL
+FEISHU_API_BASE = "https://open.feishu.cn/open-apis"
+
+
+class RateLimiter:
+    """
+    Rate limiter for Feishu API.
+
+    Feishu limits:
+    - Same chat: ~5 msg/sec
+    - Total: ~100 msg/sec
+    """
+
+    def __init__(self, max_per_second: float = 5.0):
+        self.min_interval = 1.0 / max_per_second
+        self.last_send: Dict[str, float] = {}
+        self.lock = threading.Lock()
+
+    def acquire(self, chat_id: str) -> float:
+        """
+        Check if we can send to this chat.
+        Returns wait time in seconds (0 if can send immediately).
+        """
+        with self.lock:
+            now = time.time()
+            last = self.last_send.get(chat_id, 0)
+            elapsed = now - last
+
+            if elapsed >= self.min_interval:
+                self.last_send[chat_id] = now
+                return 0.0
+            else:
+                return self.min_interval - elapsed
+
+    def wait_and_acquire(self, chat_id: str) -> None:
+        """Wait if needed, then acquire."""
+        wait_time = self.acquire(chat_id)
+        if wait_time > 0:
+            time.sleep(wait_time)
+            self.acquire(chat_id)
+
+
+class FeishuAdapter(IMAdapter):
+    """
+    Feishu adapter using WebSocket for inbound and REST API for outbound.
+    """
+
+    platform = "feishu"
+
+    def __init__(
+        self,
+        app_id: str,
+        app_secret: str,
+        log_path: Optional[Path] = None,
+        max_chars: int = DEFAULT_MAX_CHARS,
+        max_lines: int = DEFAULT_MAX_LINES,
+    ):
+        self.app_id = app_id
+        self.app_secret = app_secret
+        self.log_path = log_path
+        self.max_chars = max_chars
+        self.max_lines = max_lines
+
+        # Token management
+        self._token: str = ""
+        self._token_expires: float = 0
+        self._token_lock = threading.Lock()
+
+        # Message queue (thread-safe)
+        self._message_queue: List[Dict[str, Any]] = []
+        self._queue_lock = threading.Lock()
+
+        # Rate limiter
+        self._rate_limiter = RateLimiter(max_per_second=5.0)
+
+        # Connection state
+        self._connected = False
+        self._ws_thread: Optional[threading.Thread] = None
+        self._ws_running = False
+
+        # Cache for chat titles
+        self._chat_title_cache: Dict[str, str] = {}
+
+    def _log(self, msg: str) -> None:
+        """Append to log file if configured."""
+        if self.log_path:
+            try:
+                self.log_path.parent.mkdir(parents=True, exist_ok=True)
+                with self.log_path.open("a", encoding="utf-8") as f:
+                    ts = time.strftime("%Y-%m-%d %H:%M:%S")
+                    f.write(f"{ts} [feishu] {msg}\n")
+            except Exception:
+                pass
+
+    def _get_token(self) -> str:
+        """Get valid tenant_access_token, refreshing if needed."""
+        with self._token_lock:
+            now = time.time()
+            # Refresh 5 minutes before expiry
+            if self._token and now < self._token_expires - 300:
+                return self._token
+
+            # Refresh token
+            if self._refresh_token():
+                return self._token
+            return ""
+
+    def _refresh_token(self) -> bool:
+        """
+        Refresh tenant_access_token.
+        Token expires in 2 hours.
+        """
+        url = f"{FEISHU_API_BASE}/auth/v3/tenant_access_token/internal"
+        data = json.dumps({
+            "app_id": self.app_id,
+            "app_secret": self.app_secret,
+        }, ensure_ascii=False).encode("utf-8")
+
+        req = urllib.request.Request(url, data=data, method="POST")
+        req.add_header("Content-Type", "application/json; charset=utf-8")
+
+        try:
+            with urllib.request.urlopen(req, timeout=10) as resp:
+                body = resp.read().decode("utf-8", errors="replace")
+                result = json.loads(body)
+
+                if result.get("code") == 0:
+                    self._token = result.get("tenant_access_token", "")
+                    expire = int(result.get("expire", 7200))
+                    self._token_expires = time.time() + expire
+                    self._log(f"[token] Refreshed, expires in {expire}s")
+                    return True
+                else:
+                    self._log(f"[token] Failed: {result.get('msg', 'unknown')}")
+                    return False
+        except Exception as e:
+            self._log(f"[token] Error: {e}")
+            return False
+
+    def _api(
+        self,
+        method: str,
+        endpoint: str,
+        body: Optional[Dict[str, Any]] = None,
+        timeout: int = 15,
+    ) -> Dict[str, Any]:
+        """
+        Call Feishu API.
+
+        Args:
+            method: HTTP method (GET, POST, etc.)
+            endpoint: API endpoint (e.g., /im/v1/messages)
+            body: Request body (for POST/PUT)
+            timeout: Request timeout in seconds
+        """
+        token = self._get_token()
+        if not token:
+            return {"code": -1, "msg": "No valid token"}
+
+        url = f"{FEISHU_API_BASE}{endpoint}"
+
+        if method == "GET" and body:
+            # Convert body to query params for GET
+            query = urllib.parse.urlencode(body)
+            url = f"{url}?{query}"
+            data = None
+        else:
+            data = json.dumps(body or {}, ensure_ascii=False).encode("utf-8") if body else None
+
+        req = urllib.request.Request(url, data=data, method=method)
+        req.add_header("Authorization", f"Bearer {token}")
+        req.add_header("Content-Type", "application/json; charset=utf-8")
+        req.add_header("Accept", "application/json")
+
+        try:
+            with urllib.request.urlopen(req, timeout=timeout) as resp:
+                result_body = resp.read().decode("utf-8", errors="replace")
+                return json.loads(result_body)
+        except urllib.error.HTTPError as e:
+            http_status = e.code
+            err_text = ""
+            try:
+                err_text = e.read().decode("utf-8", "ignore")[:300]
+            except Exception:
+                pass
+            self._log(f"[api] {method} {endpoint}: HTTP {http_status} - {err_text}")
+            return {"code": http_status, "msg": str(e), "error": err_text}
+        except Exception as e:
+            self._log(f"[api] {method} {endpoint}: {e}")
+            return {"code": -1, "msg": str(e)}
+
+    def connect(self) -> bool:
+        """
+        Initialize connection to Feishu.
+
+        1. Verify credentials by getting token
+        2. Start WebSocket event listener
+        """
+        # Get initial token
+        if not self._refresh_token():
+            self._log("[connect] Failed to get token")
+            return False
+
+        # Start WebSocket listener for events
+        self._start_ws_listener()
+
+        self._connected = True
+        self._log(f"[connect] Connected with app_id={self.app_id[:8]}...")
+        return True
+
+    def _start_ws_listener(self) -> None:
+        """
+        Start WebSocket listener using Feishu official SDK.
+
+        Uses lark_oapi.ws.Client for reliable long connection.
+        """
+        if self._ws_thread and self._ws_thread.is_alive():
+            return
+
+        self._ws_running = True
+
+        def ws_loop():
+            """WebSocket event loop using official Feishu SDK."""
+            self._log("[ws] Event listener starting...")
+
+            # Try to import official SDK
+            try:
+                from lark_oapi.ws import Client as WsClient
+                import lark_oapi as lark
+            except ImportError:
+                self._log("[ws] lark-oapi not installed")
+                self._log("[ws] Install with: pip install lark-oapi")
+                while self._ws_running:
+                    time.sleep(5.0)
+                return
+
+            # Clear proxy env vars that might interfere
+            import os
+            for key in ['HTTP_PROXY', 'HTTPS_PROXY', 'http_proxy', 'https_proxy', 'ALL_PROXY', 'all_proxy']:
+                os.environ.pop(key, None)
+
+            # Event handler function - SDK passes single data argument
+            def on_p2_im_message_receive_v1(data):
+                """Handle incoming im.message.receive_v1 event from SDK."""
+                try:
+                    self._log(f"[ws] Received message event: {type(data).__name__}")
+
+                    # SDK provides structured event object
+                    event_data = {
+                        "message": {},
+                        "sender": {"sender_id": {}}
+                    }
+
+                    # Extract message info from SDK event object
+                    if hasattr(data, 'event') and data.event:
+                        event_obj = data.event
+
+                        if hasattr(event_obj, 'message') and event_obj.message:
+                            msg = event_obj.message
+                            event_data["message"] = {
+                                "message_id": getattr(msg, 'message_id', '') or '',
+                                "chat_id": getattr(msg, 'chat_id', '') or '',
+                                "chat_type": getattr(msg, 'chat_type', '') or '',
+                                "message_type": getattr(msg, 'message_type', '') or '',
+                                "content": getattr(msg, 'content', '{}') or '{}',
+                                "root_id": getattr(msg, 'root_id', '') or '',
+                            }
+                            self._log(f"[ws] Message from chat: {event_data['message']['chat_id']}")
+                            self._log(f"[ws] Message type: {event_data['message']['message_type']}")
+                            self._log(f"[ws] Content: {event_data['message']['content'][:100]}")
+
+                        if hasattr(event_obj, 'sender') and event_obj.sender:
+                            sender = event_obj.sender
+                            event_data["sender"]["sender_type"] = getattr(sender, 'sender_type', '') or ''
+
+                            if hasattr(sender, 'sender_id') and sender.sender_id:
+                                sid = sender.sender_id
+                                event_data["sender"]["sender_id"] = {
+                                    "open_id": getattr(sid, 'open_id', '') or '',
+                                    "user_id": getattr(sid, 'user_id', '') or '',
+                                }
+                            self._log(f"[ws] Sender: {event_data['sender']}")
+
+                    # Wrap in expected format for _enqueue_message
+                    full_event = {
+                        "header": {"event_type": "im.message.receive_v1"},
+                        "event": event_data
+                    }
+                    self._enqueue_message(full_event)
+                    self._log("[ws] Message enqueued successfully")
+
+                except Exception as e:
+                    self._log(f"[ws] Event handler error: {e}")
+                    import traceback
+                    self._log(f"[ws] Traceback: {traceback.format_exc()}")
+
+            try:
+                # Create WebSocket client with event handler
+                event_handler = lark.EventDispatcherHandler.builder("", "") \
+                    .register_p2_im_message_receive_v1(on_p2_im_message_receive_v1) \
+                    .build()
+
+                self._ws_client = WsClient(
+                    app_id=self.app_id,
+                    app_secret=self.app_secret,
+                    event_handler=event_handler,
+                    log_level=lark.LogLevel.DEBUG,
+                )
+
+                self._log("[ws] Starting Feishu SDK WebSocket client...")
+
+                # start() is blocking, runs until stopped
+                self._ws_client.start()
+
+            except Exception as e:
+                self._log(f"[ws] SDK error: {e}")
+                import traceback
+                self._log(f"[ws] Traceback: {traceback.format_exc()}")
+
+            self._log("[ws] Event listener stopped")
+
+        self._ws_thread = threading.Thread(target=ws_loop, daemon=True)
+        self._ws_thread.start()
+
+    def disconnect(self) -> None:
+        """Disconnect from Feishu."""
+        self._connected = False
+        self._ws_running = False
+
+        # Stop SDK client if running
+        if hasattr(self, '_ws_client') and self._ws_client:
+            try:
+                self._ws_client.stop()
+            except Exception:
+                pass
+
+        if self._ws_thread:
+            self._ws_thread.join(timeout=2.0)
+        self._log("[disconnect] Disconnected")
+
+    def poll(self) -> List[Dict[str, Any]]:
+        """
+        Poll for new messages.
+
+        Returns queued messages from WebSocket listener.
+        """
+        if not self._connected:
+            return []
+
+        with self._queue_lock:
+            messages = self._message_queue.copy()
+            self._message_queue.clear()
+
+        return messages
+
+    def _enqueue_message(self, event: Dict[str, Any]) -> None:
+        """
+        Process incoming event and enqueue normalized message.
+
+        Called by WebSocket listener when receiving im.message.receive_v1 event.
+        """
+        try:
+            header = event.get("header", {})
+            event_type = header.get("event_type", "")
+
+            if event_type != "im.message.receive_v1":
+                return
+
+            payload = event.get("event", {})
+            message = payload.get("message", {})
+            sender = payload.get("sender", {})
+
+            # Extract message content
+            msg_type = message.get("message_type", "")
+            content_str = message.get("content", "{}")
+
+            try:
+                content = json.loads(content_str)
+            except Exception:
+                content = {}
+
+            # Extract text based on message type
+            if msg_type == "text":
+                text = content.get("text", "")
+            elif msg_type == "post":
+                # Rich text - extract plain text
+                text = self._extract_post_text(content)
+            elif msg_type == "image":
+                text = "[image]"
+            elif msg_type == "file":
+                text = f"[file: {content.get('file_name', 'unknown')}]"
+            else:
+                text = f"[{msg_type}]"
+
+            if not text.strip():
+                return
+
+            # Build attachments list
+            attachments: List[Dict[str, Any]] = []
+            if msg_type == "image":
+                attachments.append({
+                    "provider": "feishu",
+                    "kind": "image",
+                    "image_key": content.get("image_key", ""),
+                    "file_name": "image.png",
+                })
+            elif msg_type == "file":
+                attachments.append({
+                    "provider": "feishu",
+                    "kind": "file",
+                    "file_key": content.get("file_key", ""),
+                    "file_name": content.get("file_name", "file"),
+                })
+
+            # Get sender info
+            sender_id = sender.get("sender_id", {})
+            open_id = sender_id.get("open_id", "")
+            sender_type = sender.get("sender_type", "")
+
+            # Skip bot's own messages
+            if sender_type == "app":
+                return
+
+            # Normalize message
+            chat_id = message.get("chat_id", "")
+            chat_type = message.get("chat_type", "")  # p2p, group
+
+            normalized = {
+                "chat_id": chat_id,
+                "chat_title": self._get_chat_title_cached(chat_id),
+                "chat_type": chat_type,
+                "thread_id": message.get("root_id", 0) or 0,
+                "text": text,
+                "attachments": attachments,
+                "from_user": open_id,
+                "message_id": message.get("message_id", ""),
+            }
+
+            with self._queue_lock:
+                self._message_queue.append(normalized)
+
+        except Exception as e:
+            self._log(f"[enqueue] Error: {e}")
+
+    def _extract_post_text(self, content: Dict[str, Any]) -> str:
+        """Extract plain text from rich text (post) content."""
+        texts = []
+        try:
+            # Post content structure: {"title": "...", "content": [[{tag, ...}]]}
+            title = content.get("title", "")
+            if title:
+                texts.append(title)
+
+            for line in content.get("content", []):
+                for elem in line:
+                    tag = elem.get("tag", "")
+                    if tag == "text":
+                        texts.append(elem.get("text", ""))
+                    elif tag == "a":
+                        texts.append(elem.get("text", elem.get("href", "")))
+                    elif tag == "at":
+                        texts.append(f"@{elem.get('user_name', 'user')}")
+        except Exception:
+            pass
+        return " ".join(texts)
+
+    def _get_chat_title_cached(self, chat_id: str) -> str:
+        """Get chat title with caching."""
+        if chat_id in self._chat_title_cache:
+            return self._chat_title_cache[chat_id]
+
+        title = self.get_chat_title(chat_id)
+        self._chat_title_cache[chat_id] = title
+        return title
+
+    def send_message(self, chat_id: str, text: str, thread_id: Optional[int] = None) -> bool:
+        """
+        Send a text message to a chat.
+
+        Args:
+            chat_id: Feishu chat_id (oc_xxx)
+            text: Message text
+            thread_id: Optional root_id for threading
+        """
+        if not text:
+            return True
+
+        if not self._connected:
+            return False
+
+        # Ensure message fits limit
+        safe_text = self._compose_safe(text)
+
+        # Rate limit
+        self._rate_limiter.wait_and_acquire(chat_id)
+
+        # Build message content
+        content = json.dumps({"text": safe_text}, ensure_ascii=False)
+
+        params: Dict[str, Any] = {
+            "receive_id_type": "chat_id",
+        }
+
+        body: Dict[str, Any] = {
+            "receive_id": chat_id,
+            "msg_type": "text",
+            "content": content,
+        }
+
+        # Thread support (reply to root message)
+        if thread_id:
+            body["root_id"] = str(thread_id)
+
+        # Build URL with query params
+        query = urllib.parse.urlencode(params)
+        endpoint = f"/im/v1/messages?{query}"
+
+        resp = self._api("POST", endpoint, body)
+
+        if resp.get("code") == 0:
+            return True
+
+        self._log(f"[send] Failed to chat {chat_id}: {resp.get('msg', 'unknown')}")
+        return False
+
+    def _compose_safe(self, text: str) -> str:
+        """Ensure message fits within Feishu limits."""
+        summarized = self.summarize(text, self.max_chars, self.max_lines)
+
+        if len(summarized) > FEISHU_MAX_MESSAGE_LENGTH:
+            summarized = summarized[: FEISHU_MAX_MESSAGE_LENGTH - 1] + "..."
+
+        return summarized
+
+    def get_chat_title(self, chat_id: str) -> str:
+        """Get chat title via API."""
+        resp = self._api("GET", f"/im/v1/chats/{chat_id}")
+
+        if resp.get("code") == 0:
+            data = resp.get("data", {})
+            return data.get("name", "") or data.get("chat_id", chat_id)
+
+        return chat_id
+
+    def download_attachment(self, attachment: Dict[str, Any]) -> bytes:
+        """Download an attachment from Feishu."""
+        kind = attachment.get("kind", "")
+        token = self._get_token()
+
+        if not token:
+            raise ValueError("No valid token")
+
+        if kind == "image":
+            image_key = attachment.get("image_key", "")
+            if not image_key:
+                raise ValueError("Missing image_key")
+
+            url = f"{FEISHU_API_BASE}/im/v1/images/{image_key}"
+        elif kind == "file":
+            file_key = attachment.get("file_key", "")
+            if not file_key:
+                raise ValueError("Missing file_key")
+
+            url = f"{FEISHU_API_BASE}/im/v1/files/{file_key}"
+        else:
+            raise ValueError(f"Unknown attachment kind: {kind}")
+
+        req = urllib.request.Request(url, method="GET")
+        req.add_header("Authorization", f"Bearer {token}")
+
+        try:
+            with urllib.request.urlopen(req, timeout=30) as resp:
+                return resp.read()
+        except Exception as e:
+            raise ValueError(f"Download failed: {e}")
+
+    def send_file(
+        self,
+        chat_id: str,
+        *,
+        file_path: Path,
+        filename: str,
+        caption: str = "",
+        thread_id: Optional[int] = None,
+    ) -> bool:
+        """Send a file to a chat."""
+        if not self._connected:
+            return False
+
+        token = self._get_token()
+        if not token:
+            return False
+
+        # Rate limit
+        self._rate_limiter.wait_and_acquire(chat_id)
+
+        try:
+            raw = file_path.read_bytes()
+        except Exception as e:
+            self._log(f"[send_file] Read failed: {e}")
+            return False
+
+        # Step 1: Upload file to get file_key
+        boundary = "----cccc" + uuid.uuid4().hex
+        upload_url = f"{FEISHU_API_BASE}/im/v1/files"
+
+        safe_fn = (filename or file_path.name or "file").replace("\\", "_").replace("/", "_")
+
+        # Build multipart form data
+        body = b""
+
+        # file_type field (opus, mp4, pdf, doc, xls, ppt, stream)
+        body += (
+            f"--{boundary}\r\n"
+            f'Content-Disposition: form-data; name="file_type"\r\n\r\n'
+            f"stream\r\n"
+        ).encode("utf-8")
+
+        # file_name field
+        body += (
+            f"--{boundary}\r\n"
+            f'Content-Disposition: form-data; name="file_name"\r\n\r\n'
+            f"{safe_fn}\r\n"
+        ).encode("utf-8")
+
+        # file field
+        body += (
+            f"--{boundary}\r\n"
+            f'Content-Disposition: form-data; name="file"; filename="{safe_fn}"\r\n'
+            f"Content-Type: application/octet-stream\r\n\r\n"
+        ).encode("utf-8")
+        body += raw
+        body += f"\r\n--{boundary}--\r\n".encode("utf-8")
+
+        req = urllib.request.Request(upload_url, data=body, method="POST")
+        req.add_header("Authorization", f"Bearer {token}")
+        req.add_header("Content-Type", f"multipart/form-data; boundary={boundary}")
+
+        try:
+            with urllib.request.urlopen(req, timeout=60) as resp:
+                result = json.loads(resp.read().decode("utf-8", errors="replace"))
+
+            if result.get("code") != 0:
+                self._log(f"[send_file] Upload failed: {result.get('msg', 'unknown')}")
+                return False
+
+            file_key = result.get("data", {}).get("file_key", "")
+            if not file_key:
+                self._log("[send_file] No file_key in response")
+                return False
+
+        except Exception as e:
+            self._log(f"[send_file] Upload error: {e}")
+            return False
+
+        # Step 2: Send file message
+        content = json.dumps({"file_key": file_key}, ensure_ascii=False)
+
+        params: Dict[str, Any] = {
+            "receive_id_type": "chat_id",
+        }
+
+        msg_body: Dict[str, Any] = {
+            "receive_id": chat_id,
+            "msg_type": "file",
+            "content": content,
+        }
+
+        if thread_id:
+            msg_body["root_id"] = str(thread_id)
+
+        query = urllib.parse.urlencode(params)
+        endpoint = f"/im/v1/messages?{query}"
+
+        resp = self._api("POST", endpoint, msg_body)
+
+        if resp.get("code") == 0:
+            # Send caption as separate message if provided
+            if caption:
+                self.send_message(chat_id, caption, thread_id)
+            return True
+
+        self._log(f"[send_file] Send failed: {resp.get('msg', 'unknown')}")
+        return False
+
+    def format_outbound(self, by: str, to: List[str], text: str, is_system: bool = False) -> str:
+        """Format message for Feishu display."""
+        formatted = super().format_outbound(by, to, text, is_system)
+        return self._compose_safe(formatted)
+
+    # ===== WebSocket Event Handling (for webhook integration) =====
+
+    def handle_webhook_event(self, event: Dict[str, Any]) -> Optional[Dict[str, Any]]:
+        """
+        Handle incoming webhook event from Feishu.
+
+        This method should be called by an external HTTP server
+        when receiving events from Feishu webhook.
+
+        Returns challenge response if needed, None otherwise.
+        """
+        # Handle URL verification challenge
+        if "challenge" in event:
+            return {"challenge": event["challenge"]}
+
+        # Handle regular events
+        schema = event.get("schema", "")
+
+        if schema == "2.0":
+            # Event v2 format
+            self._enqueue_message(event)
+        else:
+            # Event v1 format (legacy)
+            wrapped = {
+                "header": {
+                    "event_type": event.get("event", {}).get("type", ""),
+                },
+                "event": event.get("event", {}),
+            }
+            self._enqueue_message(wrapped)
+
+        return None

--- a/web/src/components/SettingsModal.tsx
+++ b/web/src/components/SettingsModal.tsx
@@ -1,6 +1,6 @@
 // SettingsModal renders the settings modal.
 import { useState, useEffect } from "react";
-import { Actor, GroupDoc, GroupSettings, IMStatus } from "../types";
+import { Actor, GroupDoc, GroupSettings, IMStatus, IMPlatform } from "../types";
 import * as api from "../services/api";
 import { useObservabilityStore } from "../stores";
 import {
@@ -70,9 +70,15 @@ export function SettingsModal({
 
   // IM Bridge state
   const [imStatus, setImStatus] = useState<IMStatus | null>(null);
-  const [imPlatform, setImPlatform] = useState<"telegram" | "slack" | "discord">("telegram");
+  const [imPlatform, setImPlatform] = useState<IMPlatform>("telegram");
   const [imBotTokenEnv, setImBotTokenEnv] = useState("");
   const [imAppTokenEnv, setImAppTokenEnv] = useState("");
+  // Feishu fields
+  const [imFeishuAppId, setImFeishuAppId] = useState("");
+  const [imFeishuAppSecret, setImFeishuAppSecret] = useState("");
+  // DingTalk fields
+  const [imDingtalkAppKey, setImDingtalkAppKey] = useState("");
+  const [imDingtalkAppSecret, setImDingtalkAppSecret] = useState("");
   const [imBusy, setImBusy] = useState(false);
 
   // Global observability (developer mode)
@@ -141,7 +147,7 @@ export function SettingsModal({
       if (statusResp.ok) {
         setImStatus(statusResp.result);
         if (statusResp.result.platform) {
-          setImPlatform(statusResp.result.platform as "telegram" | "slack" | "discord");
+          setImPlatform(statusResp.result.platform as IMPlatform);
         }
       }
       const configResp = await api.fetchIMConfig(groupId);
@@ -150,6 +156,12 @@ export function SettingsModal({
         if (im.platform) setImPlatform(im.platform);
         setImBotTokenEnv(im.bot_token_env || im.token_env || im.token || "");
         setImAppTokenEnv(im.app_token_env || "");
+        // Feishu fields
+        setImFeishuAppId(im.feishu_app_id || "");
+        setImFeishuAppSecret(im.feishu_app_secret || "");
+        // DingTalk fields
+        setImDingtalkAppKey(im.dingtalk_app_key || "");
+        setImDingtalkAppSecret(im.dingtalk_app_secret || "");
       }
     } catch (e) {
       console.error("Failed to load IM status:", e);
@@ -305,7 +317,12 @@ export function SettingsModal({
     if (!groupId) return;
     setImBusy(true);
     try {
-      const resp = await api.setIMConfig(groupId, imPlatform, imBotTokenEnv, imAppTokenEnv);
+      const resp = await api.setIMConfig(groupId, imPlatform, imBotTokenEnv, imAppTokenEnv, {
+        feishu_app_id: imFeishuAppId,
+        feishu_app_secret: imFeishuAppSecret,
+        dingtalk_app_key: imDingtalkAppKey,
+        dingtalk_app_secret: imDingtalkAppSecret,
+      });
       if (resp.ok) await loadIMStatus();
     } catch (e) {
       console.error("Failed to save IM config:", e);
@@ -322,6 +339,10 @@ export function SettingsModal({
       if (resp.ok) {
         setImBotTokenEnv("");
         setImAppTokenEnv("");
+        setImFeishuAppId("");
+        setImFeishuAppSecret("");
+        setImDingtalkAppKey("");
+        setImDingtalkAppSecret("");
         await loadIMStatus();
       }
     } catch (e) {
@@ -630,6 +651,14 @@ export function SettingsModal({
               setImBotTokenEnv={setImBotTokenEnv}
               imAppTokenEnv={imAppTokenEnv}
               setImAppTokenEnv={setImAppTokenEnv}
+              imFeishuAppId={imFeishuAppId}
+              setImFeishuAppId={setImFeishuAppId}
+              imFeishuAppSecret={imFeishuAppSecret}
+              setImFeishuAppSecret={setImFeishuAppSecret}
+              imDingtalkAppKey={imDingtalkAppKey}
+              setImDingtalkAppKey={setImDingtalkAppKey}
+              imDingtalkAppSecret={imDingtalkAppSecret}
+              setImDingtalkAppSecret={setImDingtalkAppSecret}
               imBusy={imBusy}
               onSaveConfig={handleSaveIMConfig}
               onRemoveConfig={handleRemoveIMConfig}

--- a/web/src/types.ts
+++ b/web/src/types.ts
@@ -182,14 +182,22 @@ export type GroupSettings = {
   terminal_transcript_notify_lines: number;
 };
 
+export type IMPlatform = "telegram" | "slack" | "discord" | "feishu" | "dingtalk";
+
 export type IMConfig = {
-  platform?: "telegram" | "slack" | "discord";
+  platform?: IMPlatform;
   // Legacy single token field (backward compat)
   token_env?: string;
   token?: string;
   // Dual token fields for Slack (bot_token for outbound, app_token for inbound)
   bot_token_env?: string;
   app_token_env?: string;
+  // Feishu fields
+  feishu_app_id?: string;
+  feishu_app_secret?: string;
+  // DingTalk fields
+  dingtalk_app_key?: string;
+  dingtalk_app_secret?: string;
 };
 
 export type IMStatus = {


### PR DESCRIPTION
- Updated `start_bridge` function to handle Feishu and DingTalk configurations.
- Enhanced `IMSetRequest` model to include fields for Feishu and DingTalk.
- Modified `create_app` to set environment variables for Feishu and DingTalk.
- Updated frontend components to manage new platform settings, including input fields for Feishu App ID, App Secret, DingTalk App Key, and App Secret.
- Adjusted API service to accommodate new platform configurations in `setIMConfig`.
- Expanded type definitions to include new IM platforms.