### PR TITLE
docs: add Feishu and DingTalk platform documentation

### DIFF
--- a/docs/vnext/FEATURES.md
+++ b/docs/vnext/FEATURES.md
@@ -62,6 +62,8 @@ daemon 解析 to 字段
 | Telegram | ✅ 完成 | `token_env` |
 | Slack | ✅ 完成 | `bot_token_env` + `app_token_env` |
 | Discord | ✅ 完成 | `token_env` |
+| Feishu | ✅ 完成 | `FEISHU_APP_ID` + `FEISHU_APP_SECRET` |
+| DingTalk | ✅ 完成 | `DINGTALK_APP_KEY` + `DINGTALK_APP_SECRET` |
 
 ### 2.3 配置
 
@@ -76,6 +78,19 @@ im:
   platform: slack
   bot_token_env: SLACK_BOT_TOKEN    # xoxb-... Web API
   app_token_env: SLACK_APP_TOKEN    # xapp-... Socket Mode
+
+# Feishu 使用环境变量（App ID/Secret）
+# export FEISHU_APP_ID=xxx
+# export FEISHU_APP_SECRET=xxx
+im:
+  platform: feishu
+
+# DingTalk 使用环境变量（App Key/Secret；可选 Robot Code）
+# export DINGTALK_APP_KEY=xxx
+# export DINGTALK_APP_SECRET=xxx
+# export DINGTALK_ROBOT_CODE=xxx  # optional
+im:
+  platform: dingtalk
 ```
 
 ### 2.4 IM 命令

--- a/docs/vnext/STATUS.md
+++ b/docs/vnext/STATUS.md
@@ -41,6 +41,8 @@
 - Telegram adapter 完成
 - Slack adapter 完成（Socket Mode + Web API）
 - Discord adapter 完成（Gateway）
+- Feishu adapter 完成（WebSocket + REST）
+- DingTalk adapter 完成（Stream mode + REST）
 - CLI 命令完成
 - Web UI 配置完成
 


### PR DESCRIPTION
## Summary

- Add Feishu (飞书) and DingTalk (钉钉) platform configuration to FEATURES.md
- Update STATUS.md to reflect completed adapter status for both platforms

## Changes

- `docs/vnext/FEATURES.md`: Added platform table entries and configuration examples for Feishu and DingTalk
- `docs/vnext/STATUS.md`: Added completion status for Feishu and DingTalk adapters