### PR TITLE
fix(mcp): omit nextCursor when no more pages in tools/list

### DIFF
--- a/src/cccc/ports/mcp/main.py
+++ b/src/cccc/ports/mcp/main.py
@@ -141,10 +141,10 @@ def handle_request(req: Dict[str, Any]) -> Dict[str, Any]:
             limit = 100
         limit = max(1, min(limit, 200))
         page = tools[cursor : cursor + limit]
-        next_cursor = ""
+        result_payload: Dict[str, Any] = {"tools": page}
         if cursor + limit < len(tools):
-            next_cursor = _encode_cursor(cursor + limit)
-        return _make_response(req_id, {"tools": page, "nextCursor": next_cursor})
+            result_payload["nextCursor"] = _encode_cursor(cursor + limit)
+        return _make_response(req_id, result_payload)
 
     # Optional MCP surfaces (return empty to avoid noisy "Method not found" in some runtimes)
     if method == "resources/list":


### PR DESCRIPTION
Previously, tools/list always returned `"nextCursor": ""` even when all tools fit in a single page. Cursor-agent treats any present nextCursor (including empty string) as "more pages available", causing an infinite pagination loop (~170k requests in 55s) that exhausts the V8 heap and crashes with OOM.

Only include nextCursor in the response when there are actually more pages to fetch.

Made-with: Cursor