### PR TITLE
fix(encoding):convert files from UTF-8 to UTF-8 BOM.

### DIFF
--- a/scripts/build_package.ps1
+++ b/scripts/build_package.ps1
@@ -1,4 +1,4 @@
-param(
+﻿param(
   [switch]$InstallDeps,
   [string]$Python = "python"
 )

--- a/scripts/build_web.ps1
+++ b/scripts/build_web.ps1
@@ -1,4 +1,4 @@
-param(
+﻿param(
   [switch]$InstallDeps
 )
 


### PR DESCRIPTION
中文环境下的Windows10系统，若未在区域与语言中启用beta版本的utf-8语言支持，那么在执行ps1 powershell脚本文件时会因编码问题报错：

> 表达式或语句中包含意外的标记“Web”。
> 所在位置 E:\Python\shierkeji\cccc\scripts\build_web.ps1:26 字符: 63
> + Write-Host "OK: 宸叉瀯寤?bundled Web UI -> src/cccc/ports/web/dist"
> +                                                               ~
> 字符串缺少终止符: "。
> 所在位置 E:\Python\shierkeji\cccc\scripts\build_web.ps1:12 字符: 59
> + if (-not (Get-Command npm -ErrorAction SilentlyContinue)) {
> +                                                           ~
> 语句块或类型定义中缺少右“}”。
>     + CategoryInfo          : ParserError: (:) [], ParentContainsErrorRecordEx 
>    ception
>     + FullyQualifiedErrorId : UnexpectedToken

修改为带BOM的UTF-8编码即可解决