### PR TITLE
Use terminal state for Codex profile-backed PTY actors

### DIFF
--- a/src/cccc/kernel/actors.py
+++ b/src/cccc/kernel/actors.py
@@ -244,6 +244,7 @@ def add_actor(
             runtime=runtime_name,
             runner=runner_kind,
             requested_source=runtime_state_source,
+            command=command_list,
         ),
         internal_kind=(str(internal_kind or "").strip() or None),
         created_at=now,
@@ -446,6 +447,15 @@ def update_actor(group: Group, actor_id: str, patch: Dict[str, Any]) -> Dict[str
 
     if str(item.get("runtime") or "").strip() != "codex" or str(item.get("runner") or "pty").strip() != "pty":
         item["runtime_state_source"] = "terminal"
+    elif "runtime_state_source" not in patch and "command" in patch:
+        inferred_source = default_runtime_state_source(
+            runtime=str(item.get("runtime") or ""),
+            runner=str(item.get("runner") or ""),
+            requested_source=None,
+            command=list(item.get("command") or []) if isinstance(item.get("command"), list) else [],
+        )
+        if inferred_source == "terminal":
+            item["runtime_state_source"] = "terminal"
     elif "runtime_state_source" not in patch and (
         "runtime" in patch or "runner" in patch or not str(item.get("runtime_state_source") or "").strip()
     ):
@@ -453,6 +463,7 @@ def update_actor(group: Group, actor_id: str, patch: Dict[str, Any]) -> Dict[str
             runtime=str(item.get("runtime") or ""),
             runner=str(item.get("runner") or ""),
             requested_source=None,
+            command=list(item.get("command") or []) if isinstance(item.get("command"), list) else [],
         )
 
     if "internal_kind" in patch:

--- a/src/cccc/kernel/runtime_state_source.py
+++ b/src/cccc/kernel/runtime_state_source.py
@@ -1,8 +1,64 @@
 from __future__ import annotations
 
+import ntpath
+from pathlib import Path
 from typing import Any
 
 from ..contracts.v1.actor import RuntimeStateSource
+
+
+_CODEX_PROVIDER_CONFIG_KEYS = (
+    "openai_base_url",
+    "model_provider",
+    "model_providers",
+)
+
+
+def _command_stem(command: str) -> str:
+    raw = str(command or "").strip()
+    if not raw:
+        return ""
+    try:
+        return str(Path(ntpath.basename(raw)).stem or "").strip().lower()
+    except Exception:
+        return raw.lower()
+
+
+def _codex_config_key(value: str) -> str:
+    return str(value or "").split("=", 1)[0].strip()
+
+
+def codex_pty_command_prefers_terminal_state(command: list[str] | None) -> bool:
+    """Return whether a Codex PTY command must run as the actual terminal process."""
+
+    items = [str(item or "").strip() for item in list(command or []) if str(item or "").strip()]
+    if not items:
+        return False
+    stem = _command_stem(items[0])
+    if stem != "codex":
+        return False
+
+    i = 1
+    while i < len(items):
+        arg = items[i]
+        if arg in {"-p", "--profile", "--oss", "--local-provider"}:
+            return True
+        if arg.startswith("--profile=") or arg.startswith("--local-provider="):
+            return True
+        if arg in {"-c", "--config"}:
+            if i + 1 < len(items):
+                key = _codex_config_key(items[i + 1])
+                if any(key == wanted or key.startswith(f"{wanted}.") for wanted in _CODEX_PROVIDER_CONFIG_KEYS):
+                    return True
+            i += 2
+            continue
+        if arg.startswith("--config="):
+            key = _codex_config_key(arg.split("=", 1)[1])
+            if any(key == wanted or key.startswith(f"{wanted}.") for wanted in _CODEX_PROVIDER_CONFIG_KEYS):
+                return True
+        i += 1
+
+    return False
 
 
 def default_runtime_state_source(
@@ -10,11 +66,14 @@ def default_runtime_state_source(
     runtime: str,
     runner: str,
     requested_source: str | None = None,
+    command: list[str] | None = None,
 ) -> RuntimeStateSource:
     source = str(requested_source or "").strip().lower()
     if source in {"terminal", "app_server"}:
         return source  # type: ignore[return-value]
     if str(runtime or "").strip().lower() == "codex" and str(runner or "pty").strip().lower() == "pty":
+        if codex_pty_command_prefers_terminal_state(command):
+            return "terminal"
         return "app_server"
     return "terminal"
 

--- a/tests/test_runtime_state_source.py
+++ b/tests/test_runtime_state_source.py
@@ -1,8 +1,19 @@
+import pytest
+
 from cccc.kernel.runtime_state_source import default_runtime_state_source
 
 
-def test_codex_pty_defaults_to_app_server_state_source() -> None:
-    assert default_runtime_state_source(runtime="codex", runner="pty") == "app_server"
+@pytest.mark.parametrize(
+    ("command", "expected"),
+    [
+        (None, "app_server"),
+        (["codex", "--profile", "local", "--search"], "terminal"),
+        (["codex", "-c", "model_provider=local", "--search"], "terminal"),
+        (["codex", "-c", "shell_environment_policy.inherit=all", "--search"], "app_server"),
+    ],
+)
+def test_codex_pty_command_aware_state_source_defaults(command, expected) -> None:
+    assert default_runtime_state_source(runtime="codex", runner="pty", command=command) == expected
 
 
 def test_non_codex_pty_defaults_to_terminal_state_source() -> None:
@@ -13,8 +24,7 @@ def test_explicit_runtime_state_source_is_preserved_when_valid() -> None:
     assert default_runtime_state_source(runtime="codex", runner="pty", requested_source="terminal") == "terminal"
 
 
-def test_add_actor_applies_codex_pty_app_server_default(tmp_path, monkeypatch) -> None:
-    from cccc.kernel.actors import add_actor
+def _runtime_source_group(tmp_path, monkeypatch):
     from cccc.kernel.group import create_group, load_group
     from cccc.kernel.registry import load_registry
 
@@ -22,7 +32,44 @@ def test_add_actor_applies_codex_pty_app_server_default(tmp_path, monkeypatch) -
     group_id = create_group(load_registry(), title="runtime-source", topic="").group_id
     group = load_group(group_id)
     assert group is not None
+    return group
 
+
+def test_add_actor_applies_codex_pty_app_server_default(tmp_path, monkeypatch) -> None:
+    from cccc.kernel.actors import add_actor
+
+    group = _runtime_source_group(tmp_path, monkeypatch)
     actor = add_actor(group, actor_id="peer1", runtime="codex", runner="pty")
 
     assert actor["runtime_state_source"] == "app_server"
+
+
+def test_add_actor_applies_codex_profile_terminal_default(tmp_path, monkeypatch) -> None:
+    from cccc.kernel.actors import add_actor
+
+    group = _runtime_source_group(tmp_path, monkeypatch)
+    actor = add_actor(
+        group,
+        actor_id="peer1",
+        runtime="codex",
+        runner="pty",
+        command=["codex", "--profile", "local", "--search"],
+    )
+
+    assert actor["runtime_state_source"] == "terminal"
+
+
+def test_update_actor_switches_codex_provider_command_to_terminal_default(tmp_path, monkeypatch) -> None:
+    from cccc.kernel.actors import add_actor, update_actor
+
+    group = _runtime_source_group(tmp_path, monkeypatch)
+    actor = add_actor(group, actor_id="peer1", runtime="codex", runner="pty")
+    assert actor["runtime_state_source"] == "app_server"
+
+    actor = update_actor(
+        group,
+        "peer1",
+        {"command": ["codex", "--profile", "local", "--search"]},
+    )
+
+    assert actor["runtime_state_source"] == "terminal"


### PR DESCRIPTION
## Motivation

When using Codex with a locally deployed model, users can configure Codex through a profile or provider override, for
example `codex --profile local ...`.

CCCC currently defaults Codex PTY actors to the app-server-backed state source. That path starts its own `codex app-server --listen ...` process for state tracking. If the actor command contains a Codex profile or provider override, the separately started app-server process may not use the same local model configuration, so the actor can appear to run the configured Codex command while the model requests still follow the default Codex configuration.

## Changes

- Make the default Codex PTY runtime state source command-aware.
- Keep the existing `app_server` default for ordinary Codex PTY commands.
- Use `terminal` by default when the Codex command includes profile or provider configuration:
  - `--profile` / `-p`
  - `--oss`
  - `--local-provider`
  - `-c/--config` keys for `model_provider`, `model_providers`, or `openai_base_url`
- Recompute the default when a Codex PTY actor command is updated and no explicit `runtime_state_source` is provided.
- Add regression coverage for add/update paths and command classification.

## Testing

- `.venv/bin/python -m pytest tests/test_runtime_state_source.py`