### PR TITLE
feat: publish native installers from docs

### DIFF
--- a/.github/workflows/docs.yml
+++ b/.github/workflows/docs.yml
@@ -3,7 +3,12 @@ name: Deploy Docs
 on:
   push:
     branches: [main]
-    paths: ['docs/**']
+    paths:
+      - 'docs/**'
+      - 'scripts/install.sh'
+      - 'scripts/install.ps1'
+      - 'scripts/prepare_docs_installers.mjs'
+      - '.github/workflows/docs.yml'
   workflow_dispatch:
 
 permissions:

--- a/.github/workflows/release-rust.yml
+++ b/.github/workflows/release-rust.yml
@@ -1,6 +1,8 @@
-name: Build standalone Rust candidates (manual)
+name: Build and publish standalone Rust release
 
 on:
+  push:
+    tags: ["v*"]
   workflow_dispatch:
 
 permissions:
@@ -100,6 +102,9 @@ jobs:
         shell: bash
         run: |
           version="$(sed -n 's/^version = "\([^"]*\)"/\1/p' Cargo.toml | head -1)"
+          if [ "${GITHUB_EVENT_NAME}" = "push" ]; then
+            python scripts/check_release_versions.py --tag "${GITHUB_REF_NAME}"
+          fi
           scripts/package_release_assets.sh artifacts "$version"
       - uses: actions/upload-artifact@v4
         with:
@@ -140,3 +145,35 @@ jobs:
         if: matrix.verifier == 'windows'
         shell: pwsh
         run: ./scripts/tests/verify_release_windows.ps1 -ArtifactDir artifacts -Target "${{ matrix.target }}"
+
+  publish:
+    if: github.event_name == 'push'
+    needs: verify
+    runs-on: ubuntu-latest
+    permissions:
+      contents: write
+    steps:
+      - uses: actions/checkout@v4
+      - uses: actions/download-artifact@v4
+        with:
+          name: cccc-release-candidate
+          path: artifacts
+      - name: Publish GitHub release assets
+        shell: bash
+        env:
+          GH_TOKEN: ${{ github.token }}
+        run: |
+          python scripts/check_release_versions.py --tag "${GITHUB_REF_NAME}"
+          prerelease=()
+          case "${GITHUB_REF_NAME}" in
+            *-alpha*|*-beta*|*-rc*) prerelease=(--prerelease) ;;
+          esac
+          if gh release view "${GITHUB_REF_NAME}" >/dev/null 2>&1; then
+            gh release upload "${GITHUB_REF_NAME}" artifacts/* --clobber
+          else
+            gh release create "${GITHUB_REF_NAME}" artifacts/* \
+              --verify-tag \
+              --title "CCCC ${GITHUB_REF_NAME#v}" \
+              --generate-notes \
+              "${prerelease[@]}"
+          fi

--- a/.gitignore
+++ b/.gitignore
@@ -46,6 +46,8 @@ graphify-out
 # Docs: VitePress build artifacts
 /docs/.vitepress/cache/
 /docs/.vitepress/dist/
+/docs/public/install.sh
+/docs/public/install.ps1
 /docs/_archive_local/
 /docs/voice-secretary/**
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,10 +7,12 @@ The format follows [Keep a Changelog](https://keepachangelog.com/), and versions
 ## [Unreleased]
 
 ### Added
+- **Stable native installers are available from the documentation site.** macOS/Linux users can pipe `install.sh` to `sh`, Windows users can pipe `install.ps1` to PowerShell, and neither path requires a Rust or Python toolchain. Matching tags publish checksum-verified standalone archives to GitHub Releases, while prereleases remain explicit.
 - **One `cccc-pair` installation now contains both CCCC implementations on supported platforms.** Python remains the default, while platform wheels carry a private, version-matched Rust payload behind the stable public `cccc` launcher.
 - **Cline is now a first-class PTY runtime.** Runtime discovery, actor configuration, MCP installation and repair, Web metadata, defaults, diagnostics, documentation, and both Python and Rust tests cover the Cline CLI.
 
 ### Changed
+- **Standalone Rust installations now own their update path.** `cccc update` reuses the stable website installer, including daemon shutdown, checksum validation, rollback, and PATH-safe replacement; wheel-private Rust payloads remain owned by the Python product installer.
 - **Implementation selection and updates now have one owner.** `cccc rust` and `cccc python` switch persistently without creating competing commands on `PATH`; `cccc update` replaces the complete pip product, and Rust crates are no longer independently publishable.
 - **The global Web event stream is now a routing signal rather than a content channel.** It carries only event identity, type, time, and Group identity; clients continue to read complete events from the authorized per-Group ledger stream.
 

--- a/README.ja.md
+++ b/README.ja.md
@@ -14,7 +14,7 @@ Claude Code、Codex、ChatGPT Web など 17 のランタイムをひとつの永
 
 複数のコーディングエージェントを、ランタイム・マシン・信頼済み working group をまたぐ**永続的で協調されたチーム**として運用 — バラバラのターミナルセッションではなく。
 
-`pip install` ひとつ。ゼロインフラ、プロダクション級のパワー。
+インストールコマンドひとつ。Rust ツールチェーンも追加インフラも不要です。
 
 [![PyPI](https://img.shields.io/pypi/v/cccc-pair?label=PyPI&color=blue)](https://pypi.org/project/cccc-pair/)
 [![Python](https://img.shields.io/pypi/pyversions/cccc-pair)](https://pypi.org/project/cccc-pair/)
@@ -46,11 +46,11 @@ CCCC はエージェント群を、永続的で協調された 1 つのシステ
 - **1 つのコントロールプレーン** — Web UI、CLI、MCP、IM ブリッジがすべて同じ daemon 状態を共有します。
 - **マルチランタイム前提** — Claude Code、Codex CLI、ChatGPT Web、Grok Build などの主要ランタイムを 1 つのグループで混在運用できます。
 - **Group Bridge によるリモート連携** — 信頼済み CCCC group 同士が明示的なメッセージを交換し、許可された場合は相手のローカルリソースを調査・操作できます。
-- **ローカルファースト運用** — `pip install` ひとつで始められ、ランタイム状態は `CCCC_HOME` に置いたまま、必要時だけリモート監視へ広げられます。
+- **ローカルファースト運用** — インストールコマンドひとつで始められ、ランタイム状態は `CCCC_HOME` に置いたまま、必要時だけリモート監視へ広げられます。
 
 ## CCCC の役割
 
-CCCC は `pip install` 一つで導入完了、外部依存ゼロ — データベース不要、メッセージブローカー不要、Docker 必須ではありません。それでいて、壊れやすいマルチエージェント構成に足りない運用基盤を提供します：
+CCCC はコマンド一つで導入でき、データベース、メッセージブローカー、Docker は不要です。それでいて、壊れやすいマルチエージェント構成に足りない運用基盤を提供します：
 
 | 機能 | 実現方法 |
 |---|---|
@@ -67,7 +67,13 @@ CCCC は `pip install` 一つで導入完了、外部依存ゼロ — データ�
 ### インストール
 
 ```bash
-# 安定チャネル（PyPI）
+# macOS / Linux ネイティブ Rust バイナリ（Rust・Python 不要）
+curl -fsSL https://chesterra.github.io/cccc/install.sh | sh
+
+# Windows PowerShell（Rust・Python 不要）
+irm https://chesterra.github.io/cccc/install.ps1 | iex
+
+# 移行期間中も保守される Python 配布
 pip install -U cccc-pair
 
 # RC チャネル（TestPyPI）
@@ -77,8 +83,8 @@ pip install -U --pre \
   cccc-pair
 ```
 
-> **要件**: Python 3.11+。対応プラットフォームの wheel には、同じバージョンの
-> private Rust 実装も含まれますが、公開されるコマンドは常に 1 つの `cccc` です。
+> ネイティブ版は Linux x86-64、Intel/Apple Silicon macOS、Windows x86-64 に対応します。
+> Python 配布は Python 3.11+ が必要で、対応 wheel には同じバージョンの private Rust 実装も含まれます。
 
 ### アップグレード
 
@@ -86,10 +92,9 @@ pip install -U --pre \
 cccc update
 ```
 
-インストール種別と実行予定のコマンドを事前確認するには `cccc update --check` を使用してください。
-更新は検出した PyPI チャネルから `cccc-pair` 製品全体を置き換え、対応 wheel の
-Rust payload も同時に更新します。実際の更新ではインストール済みファイルを
-置き換える前に稼働中の Web/daemon ペアを停止します。ユーザー向けの別更新経路はありません。
+インストール種別と更新元を事前確認するには `cccc update --check` を使用してください。
+ネイティブ版は GitHub Pages の固定インストーラー、pip 版は検出した PyPI チャネルから更新します。実際の更新ではインストール済みファイルを
+置き換える前に稼働中の Web/daemon ペアを停止します。
 
 ### 起動
 
@@ -478,7 +483,20 @@ CCCC はエージェントを置き換えるものではなく、それらをチ
 
 ## インストールオプション
 
-### pip（安定版、推奨）
+### ネイティブ Rust バイナリ（推奨）
+
+```bash
+# macOS / Linux
+curl -fsSL https://chesterra.github.io/cccc/install.sh | sh
+
+# Windows PowerShell
+irm https://chesterra.github.io/cccc/install.ps1 | iex
+```
+
+GitHub Releases からチェックサム検証済みバイナリを取得します。Rust と Python は不要で、
+以後は `cccc update` で同じ経路から更新できます。
+
+### pip（安定 Python 配布）
 
 ```bash
 pip install -U cccc-pair

--- a/README.md
+++ b/README.md
@@ -14,7 +14,7 @@ for Claude Code, Codex, ChatGPT Web, and 13 more runtimes in one durable group.*
 
 Run multiple coding agents as a **persistent, coordinated team** across runtimes, machines, and trusted working groups — not a pile of disconnected terminal sessions.
 
-One `pip install`. Zero infrastructure, production-grade power.
+One install command. No Rust toolchain or infrastructure required.
 
 [![PyPI](https://img.shields.io/pypi/v/cccc-pair?label=PyPI&color=blue)](https://pypi.org/project/cccc-pair/)
 [![Python](https://img.shields.io/pypi/pyversions/cccc-pair)](https://pypi.org/project/cccc-pair/)
@@ -46,11 +46,11 @@ CCCC runs your agents as one durable, coordinated system:
 - **One control plane** — Web UI, CLI, MCP, and IM bridges all operate on the same daemon-owned state.
 - **Multi-runtime by default** — Claude Code, Codex CLI, ChatGPT Web, Grok Build, and the rest of the first-class runtimes can collaborate in one group.
 - **Group Bridge for remote teams** — trusted CCCC groups can exchange explicit messages and, when granted, inspect or work with each other's local resources.
-- **Local-first operations** — one `pip install`, runtime state in `CCCC_HOME`, and remote supervision only when you choose to expose it.
+- **Local-first operations** — one install command, runtime state in `CCCC_HOME`, and remote supervision only when you choose to expose it.
 
 ## What CCCC Does
 
-CCCC is a single `pip install` with zero external dependencies — no database, no message broker, no Docker required. Yet it gives you the pieces fragile multi-agent setups usually lack:
+CCCC installs with one command and needs no database, message broker, or Docker. Yet it gives you the pieces fragile multi-agent setups usually lack:
 
 | Capability | How |
 |---|---|
@@ -68,7 +68,13 @@ CCCC is a single `pip install` with zero external dependencies — no database, 
 ### Install
 
 ```bash
-# Stable channel (PyPI)
+# Native Rust binary on macOS or Linux (no Rust or Python toolchain required)
+curl -fsSL https://chesterra.github.io/cccc/install.sh | sh
+
+# Windows PowerShell (no Rust or Python toolchain required)
+irm https://chesterra.github.io/cccc/install.ps1 | iex
+
+# Python distribution, maintained during the migration period
 pip install -U cccc-pair
 
 # RC channel (TestPyPI)
@@ -78,9 +84,9 @@ pip install -U --pre \
   cccc-pair
 ```
 
-> **Requirement**: Python 3.11+. Supported platform wheels also contain the
-> matching private Rust implementation; one installation still provides one
-> public `cccc` command.
+> The native installer supports Linux x86-64, Intel/Apple Silicon macOS, and
+> Windows x86-64. The Python distribution requires Python 3.11+ and its supported
+> platform wheels also contain the matching private Rust implementation.
 
 ### Upgrade
 
@@ -88,10 +94,10 @@ pip install -U --pre \
 cccc update
 ```
 
-Use `cccc update --check` to inspect the command that would run. Updates always
-replace the complete `cccc-pair` product from its detected PyPI channel, including
-the matching Rust payload when the platform wheel provides one. A real update
-stops the active Web/daemon pair before replacing installed files.
+Use `cccc update --check` to inspect the detected installation and update source.
+Native installs update from the stable GitHub Pages installer; pip installs update
+the complete `cccc-pair` product from their detected PyPI channel. Both paths stop
+the active Web/daemon pair before replacing installed files.
 
 ### Launch
 
@@ -482,7 +488,20 @@ For detailed security guidance, see [SECURITY.md](SECURITY.md).
 
 ## Installation Options
 
-### pip (stable, recommended)
+### Native Rust binary (recommended)
+
+```bash
+# macOS / Linux
+curl -fsSL https://chesterra.github.io/cccc/install.sh | sh
+
+# Windows PowerShell
+irm https://chesterra.github.io/cccc/install.ps1 | iex
+```
+
+This downloads a checksum-verified binary from GitHub Releases. Rust and Python
+are not required. Run `cccc update` to upgrade through the same installer.
+
+### pip (stable Python distribution)
 
 ```bash
 pip install -U cccc-pair

--- a/README.zh-CN.md
+++ b/README.zh-CN.md
@@ -14,7 +14,7 @@ Claude Code、Codex、ChatGPT Web 等 17 种运行时，在同一个持久协作
 
 让多个 coding agent 跨运行时、跨机器、跨可信协作组作为一支**持久化、可协调的团队**运行 — 而不是一堆各自为政的终端窗口。
 
-一条 `pip install`。零基础设施，生产级能力。
+一条安装命令，无需 Rust 工具链或额外基础设施。
 
 [![PyPI](https://img.shields.io/pypi/v/cccc-pair?label=PyPI&color=blue)](https://pypi.org/project/cccc-pair/)
 [![Python](https://img.shields.io/pypi/pyversions/cccc-pair)](https://pypi.org/project/cccc-pair/)
@@ -46,11 +46,11 @@ CCCC 让你的 agent 作为一套持久、可协调的系统运行：
 - **控制面统一** — Web UI、CLI、MCP、IM 桥接全部围绕同一 daemon 运作，不会出现多套状态。
 - **多运行时是默认能力** — Claude Code、Codex CLI、ChatGPT Web、Grok Build 以及其它一线 runtime 可以在同一协作组内协同工作。
 - **Group Bridge 连接远端协作组** — 可信 CCCC group 可以显式互发消息，并在授权后读取或操作彼此的本地资源。
-- **本地优先但可远程值守** — 单条 `pip install` 即可启动，运行时状态放在 `CCCC_HOME`，需要时再通过 Web / IM 远程运维。
+- **本地优先但可远程值守** — 单条安装命令即可启动，运行时状态放在 `CCCC_HOME`，需要时再通过 Web / IM 远程运维。
 
 ## CCCC 能做什么
 
-CCCC 只需一条 `pip install`，零外部依赖 — 不需要数据库、不需要消息队列、不强制 Docker。但它补上了脆弱多智能体方案最缺的那几块能力：
+CCCC 只需一条安装命令，不需要数据库、不需要消息队列、不强制 Docker。它补上了脆弱多智能体方案最缺的那几块能力：
 
 | 能力 | 实现方式 |
 |---|---|
@@ -67,7 +67,13 @@ CCCC 只需一条 `pip install`，零外部依赖 — 不需要数据库、不�
 ### 安装
 
 ```bash
-# 稳定通道（PyPI）
+# macOS / Linux 原生 Rust 二进制（无需 Rust 或 Python 环境）
+curl -fsSL https://chesterra.github.io/cccc/install.sh | sh
+
+# Windows PowerShell（无需 Rust 或 Python 环境）
+irm https://chesterra.github.io/cccc/install.ps1 | iex
+
+# 迁移期继续维护的 Python 发行版
 pip install -U cccc-pair
 
 # RC 通道（TestPyPI）
@@ -77,8 +83,9 @@ pip install -U --pre \
   cccc-pair
 ```
 
-> **环境要求**：Python 3.11+。受支持平台的 wheel 会同时包含版本严格匹配的
-> 私有 Rust 实现，但一次安装始终只提供一个公开的 `cccc` 命令。
+> 原生安装支持 Linux x86-64、Intel/Apple Silicon macOS 和 Windows x86-64。
+> Python 发行版要求 Python 3.11+，其受支持平台 wheel 仍会包含版本严格匹配的
+> 私有 Rust 实现。
 
 ### 升级
 
@@ -86,10 +93,9 @@ pip install -U --pre \
 cccc update
 ```
 
-如需先查看检测到的安装类型和将要执行的命令，可使用 `cccc update --check`。
-升级始终从检测到的 PyPI 通道替换完整的 `cccc-pair` 产品；平台 wheel 中的
-Rust 载荷也会随同升级，不再存在第二套用户升级路径。实际升级会先停止当前
-Web/daemon 进程对，再替换已安装文件。
+如需先查看检测到的安装类型和升级来源，可使用 `cccc update --check`。原生安装
+从固定 GitHub Pages 安装器升级；pip 安装则从检测到的 PyPI 通道替换完整的
+`cccc-pair` 产品。两种路径都会先停止当前 Web/daemon 进程对，再替换已安装文件。
 
 ### 启动
 
@@ -479,7 +485,20 @@ CCCC 不替代你的 agent —— 它是让它们成为一个团队的那一层�
 
 ## 安装选项
 
-### pip（稳定版，推荐）
+### 原生 Rust 二进制（推荐）
+
+```bash
+# macOS / Linux
+curl -fsSL https://chesterra.github.io/cccc/install.sh | sh
+
+# Windows PowerShell
+irm https://chesterra.github.io/cccc/install.ps1 | iex
+```
+
+安装器会从 GitHub Releases 下载并校验二进制，不要求本机安装 Rust 或 Python。
+后续直接运行 `cccc update` 即可通过同一安装器升级。
+
+### pip（稳定 Python 发行版）
 
 ```bash
 pip install -U cccc-pair

--- a/crates/cccc-cli/README.md
+++ b/crates/cccc-cli/README.md
@@ -6,21 +6,22 @@ delivery tracking, runtime state, a Web UI, and MCP access.
 ## End-user installation
 
 ```bash
-pip install -U cccc-pair
-cccc rust
+curl -fsSL https://chesterra.github.io/cccc/install.sh | sh
 ```
 
-The PyPI platform wheel owns the public `cccc` launcher and bundles this Rust
-binary privately when supported. Upgrade the launcher, Python implementation,
-Rust payload, Web assets, and contracts together with:
+Windows PowerShell uses `irm https://chesterra.github.io/cccc/install.ps1 | iex`.
+These installers download a checksum-verified GitHub Release binary and require
+neither Rust nor Python. Upgrade it through the same channel with:
 
 ```bash
 cccc update
 ```
 
-Use `cccc update --check` to inspect the PyPI channel and command without changing
-the installation. Do not install this crate separately for normal product use;
-that would create a second `cccc` on `PATH` and bypass coordinated updates.
+Use `cccc update --check` to inspect the detected installation and update source.
+The maintained PyPI platform wheel still owns its public Python launcher and
+bundles this binary privately when supported; that private payload remains updated
+as part of the complete pip product. Do not install this crate with Cargo for
+normal product use.
 
 ## Workspace development
 
@@ -37,8 +38,8 @@ Chromium, or Microsoft Edge browser. The core CLI, daemon, MCP server, and Web U
 do not require a browser.
 
 Internal implementation crates use the `cccc-pair-*` namespace and are not
-intended to be installed directly. The manual standalone-candidate workflow is
-for engineering diagnostics; release tags publish the unified PyPI product.
+intended to be installed directly. Manual standalone workflow runs verify release
+candidates; release tags also attach the verified native assets to GitHub Releases.
 
 Project documentation and source: <https://github.com/chesterra/cccc>
 

--- a/crates/cccc-cli/src/args/mod.rs
+++ b/crates/cccc-cli/src/args/mod.rs
@@ -38,7 +38,7 @@ pub struct SetupArgs {
 
 #[derive(Debug, Args)]
 pub struct UpdateArgs {
-    /// Accepted for compatibility; product updates are owned by the public Python launcher.
+    /// Show the detected installation and update source without changing files.
     #[arg(long)]
     pub check: bool,
 }
@@ -94,7 +94,7 @@ pub enum CommandKind {
     Status,
     Doctor,
     Setup(SetupArgs),
-    /// Update the complete CCCC product through the public launcher.
+    /// Update CCCC through the installer that owns this executable.
     Update(UpdateArgs),
     Version,
     Home,

--- a/crates/cccc-cli/src/commands/mod.rs
+++ b/crates/cccc-cli/src/commands/mod.rs
@@ -5,3 +5,4 @@ pub mod group;
 pub mod integrations;
 pub mod messaging;
 pub mod setup;
+pub mod update;

--- a/crates/cccc-cli/src/commands/update.rs
+++ b/crates/cccc-cli/src/commands/update.rs
@@ -1,0 +1,110 @@
+use std::path::{Path, PathBuf};
+use std::process::Command;
+
+#[cfg(windows)]
+use std::process::Stdio;
+
+use anyhow::{Context, Result, bail};
+
+use crate::args::UpdateArgs;
+
+#[cfg(not(windows))]
+const UNIX_INSTALLER_URL: &str = "https://chesterra.github.io/cccc/install.sh";
+#[cfg(windows)]
+const WINDOWS_INSTALLER_URL: &str = "https://chesterra.github.io/cccc/install.ps1";
+const INSTALL_MARKER: &str = ".cccc-standalone";
+
+pub fn run(args: UpdateArgs) -> Result<()> {
+    let executable = std::env::current_exe().context("could not resolve the CCCC executable")?;
+    let install_dir = standalone_install_dir(&executable)?;
+
+    if args.check {
+        println!("Current version: {}", crate::PRODUCT_VERSION);
+        println!("Install directory: {}", install_dir.display());
+        println!("Installer: {}", installer_url());
+        return Ok(());
+    }
+
+    run_installer(&install_dir)
+}
+
+fn standalone_install_dir(executable: &Path) -> Result<PathBuf> {
+    let install_dir = executable
+        .parent()
+        .context("CCCC executable has no parent directory")?;
+    if !install_dir.join(INSTALL_MARKER).is_file() {
+        bail!(
+            "this Rust executable is managed by another installation; update it through that installer"
+        );
+    }
+    Ok(install_dir.to_path_buf())
+}
+
+#[cfg(not(windows))]
+fn run_installer(install_dir: &Path) -> Result<()> {
+    let status = Command::new("sh")
+        .arg("-c")
+        .arg("curl -fsSL \"$CCCC_INSTALLER_URL\" | sh")
+        .env("CCCC_INSTALLER_URL", UNIX_INSTALLER_URL)
+        .env("CCCC_INSTALL_DIR", install_dir)
+        .status()
+        .context("could not start the CCCC installer")?;
+    if !status.success() {
+        bail!("CCCC installer exited with {status}");
+    }
+    Ok(())
+}
+
+#[cfg(windows)]
+fn run_installer(install_dir: &Path) -> Result<()> {
+    let child = Command::new("powershell.exe")
+        .args([
+            "-NoLogo",
+            "-NoProfile",
+            "-ExecutionPolicy",
+            "Bypass",
+            "-Command",
+            "Wait-Process -Id $env:CCCC_UPDATE_PARENT_PID -ErrorAction SilentlyContinue; Invoke-RestMethod -Uri $env:CCCC_INSTALLER_URL | Invoke-Expression",
+        ])
+        .env("CCCC_UPDATE_PARENT_PID", std::process::id().to_string())
+        .env("CCCC_INSTALLER_URL", WINDOWS_INSTALLER_URL)
+        .env("CCCC_INSTALL_DIR", install_dir)
+        .stdin(Stdio::null())
+        .stdout(Stdio::inherit())
+        .stderr(Stdio::inherit())
+        .spawn()
+        .context("could not start the CCCC updater")?;
+    println!("Started CCCC updater (process {}).", child.id());
+    Ok(())
+}
+
+#[cfg(not(windows))]
+fn installer_url() -> &'static str {
+    UNIX_INSTALLER_URL
+}
+
+#[cfg(windows)]
+fn installer_url() -> &'static str {
+    WINDOWS_INSTALLER_URL
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn standalone_install_requires_the_installer_marker() {
+        let temp = tempfile::tempdir().expect("tempdir");
+        let executable = temp
+            .path()
+            .join(if cfg!(windows) { "cccc.exe" } else { "cccc" });
+        std::fs::write(&executable, b"binary").expect("binary");
+        assert!(standalone_install_dir(&executable).is_err());
+
+        std::fs::write(temp.path().join(INSTALL_MARKER), b"standalone-v1\n").expect("marker");
+        assert_eq!(
+            standalone_install_dir(&executable).expect("standalone install"),
+            temp.path()
+        );
+    }
+}

--- a/crates/cccc-cli/src/main.rs
+++ b/crates/cccc-cli/src/main.rs
@@ -85,9 +85,7 @@ async fn main() -> Result<()> {
         Some(CommandKind::Status) => status(&client).await,
         Some(CommandKind::Doctor) => commands::doctor::run(&home, PRODUCT_VERSION).await,
         Some(CommandKind::Setup(args)) => commands::setup::run(&home, args),
-        Some(CommandKind::Update(_)) => bail!(
-            "the Rust implementation cannot update independently; run `cccc update` through the installed cccc-pair launcher"
-        ),
+        Some(CommandKind::Update(args)) => commands::update::run(args),
     }
 }
 

--- a/docs/guide/faq.md
+++ b/docs/guide/faq.md
@@ -27,7 +27,13 @@ In short: CCCC does not replace your agents — it is the coordination layer tha
 ### How do I install CCCC?
 
 ```bash
-# From PyPI
+# Native Rust binary on macOS or Linux
+curl -fsSL https://chesterra.github.io/cccc/install.sh | sh
+
+# Native Rust binary on Windows PowerShell
+irm https://chesterra.github.io/cccc/install.ps1 | iex
+
+# Python distribution from PyPI
 pip install -U cccc-pair
 
 # From TestPyPI (explicit RC testing)
@@ -61,9 +67,11 @@ Then install the new version. Note that 0.4.x has a completely different command
 
 ### What are the system requirements?
 
-- Python 3.11+
 - macOS, Linux, or Windows
 - At least one supported agent runtime CLI
+
+The native Rust installer does not require Python or Rust. The maintained Python
+distribution requires Python 3.11+.
 
 ### How do I choose the Python or Rust implementation?
 

--- a/docs/guide/getting-started/index.md
+++ b/docs/guide/getting-started/index.md
@@ -93,6 +93,34 @@ rm -f ~/.local/bin/cccc ~/.local/bin/ccccd
 Version 0.4.x has a completely different command structure from 0.3.x. The old `init`, `run`, `bridge` commands are replaced with `attach`, `daemon`, `mcp`, etc.
 :::
 
+### Native Rust binary (recommended)
+
+macOS or Linux:
+
+```bash
+curl -fsSL https://chesterra.github.io/cccc/install.sh | sh
+```
+
+Windows PowerShell:
+
+```powershell
+irm https://chesterra.github.io/cccc/install.ps1 | iex
+```
+
+The installer downloads a checksum-verified GitHub Release binary. It does not
+require a Rust or Python toolchain. To install an explicit prerelease, set
+`CCCC_VERSION` before invoking the downloaded script:
+
+```bash
+curl -fsSL https://chesterra.github.io/cccc/install.sh | CCCC_VERSION=0.4.34-rc1 sh
+```
+
+```powershell
+$env:CCCC_VERSION = "0.4.34-rc1"
+irm https://chesterra.github.io/cccc/install.ps1 | iex
+Remove-Item Env:CCCC_VERSION
+```
+
 ### From PyPI
 
 ```bash

--- a/docs/guide/quality-gates.md
+++ b/docs/guide/quality-gates.md
@@ -90,7 +90,7 @@ that job so its boundary remains honest, but run in the separate mandatory
 `interop` job instead. All other Rust targets are still compiled, linted, and
 tested.
 
-The full Windows Rust workspace job is intentionally retired because it did not complete reliably on hosted runners. Windows keeps focused PTY compatibility coverage in `windows-smoke`; the unified release workflow builds and installs Linux, Intel/Apple Silicon macOS, and Windows native wheels before one PyPI publication. The Web job uploads its bundle and the package job consumes that artifact, so packaging tests the same bundle without rebuilding it. The `packaged_web_dist` pytest marker is reserved for assertions that require this artifact; source-only Python runs exclude it, while the package job executes it after downloading the bundle.
+The full Windows Rust workspace job is intentionally retired because it did not complete reliably on hosted runners. Windows keeps focused PTY compatibility coverage in `windows-smoke`; release workflows build and install Linux, Intel/Apple Silicon macOS, and Windows native wheels before one PyPI publication, and verify standalone archives before attaching them to GitHub Releases. The Web job uploads its bundle and the package job consumes that artifact, so packaging tests the same bundle without rebuilding it. The `packaged_web_dist` pytest marker is reserved for assertions that require this artifact; source-only Python runs exclude it, while the package job executes it after downloading the bundle.
 
 ## Stable Python Shards
 

--- a/docs/index.md
+++ b/docs/index.md
@@ -4,7 +4,7 @@ layout: home
 hero:
   name: CCCC
   text: Coordinate coding agents like a group chat
-  tagline: Read receipts, delivery tracking, and phone-side ops across 17 first-class runtimes, including Claude Code, Cline, Codex, and ChatGPT Web — local-first, one pip install
+  tagline: Read receipts, delivery tracking, and phone-side ops across 17 first-class runtimes, including Claude Code, Cline, Codex, and ChatGPT Web — local-first, one install command
   image:
     src: /logo.svg
     alt: CCCC

--- a/docs/package.json
+++ b/docs/package.json
@@ -2,7 +2,10 @@
   "name": "cccc-docs",
   "type": "module",
   "scripts": {
+    "prepare:installers": "node ../scripts/prepare_docs_installers.mjs",
+    "predev": "npm run prepare:installers",
     "dev": "vitepress dev --port 5000",
+    "prebuild": "npm run prepare:installers",
     "build": "vitepress build",
     "preview": "vitepress preview"
   },

--- a/docs/reference/cli.md
+++ b/docs/reference/cli.md
@@ -277,7 +277,8 @@ If the selection file is corrupt, ordinary commands fail visibly; an explicit
 `status`, `version`, and `update` are stable launcher commands. `status` shows
 the selected implementation, the implementation reported by a live daemon, and
 whether the bundled Rust payload is usable. `version` is the shared product
-version. `update` always upgrades the complete pip product.
+version. `update` follows the installer that owns the public executable: the
+website installer for standalone Rust, or pip for the Python distribution.
 
 The legacy `ccccd start|stop|status|run` command remains as a compatibility
 alias, but now passes through the same implementation launcher. New automation
@@ -308,17 +309,21 @@ reported without aborting the remaining setup work.
 
 ### `cccc update`
 
-Upgrade the complete CCCC product in the current Python environment.
+Upgrade CCCC through the detected installation channel.
 
 ```bash
 cccc update                        # Upgrade using the detected channel
+cccc update --check                # Show install detection + planned command
+
+# Python distribution only
 cccc update --channel stable       # Force the stable PyPI channel
 cccc update --channel rc           # Force the TestPyPI RC channel
-cccc update --check                # Show install detection + planned command
 ```
 
 Notes:
 - The default channel follows the detected install metadata when possible, then falls back to `stable`.
+- Standalone Rust installations reuse the stable GitHub Pages installer and
+  preserve their current install directory.
 - Editable and local-path installs are reported but not updated automatically.
 - A platform wheel updates the Python launcher and private Rust payload together.
 - After a successful update, CCCC stops the older Web/daemon pair; the next

--- a/docs/release/v0.4.34_release_notes.md
+++ b/docs/release/v0.4.34_release_notes.md
@@ -10,11 +10,12 @@ across multiple Working Groups.
 
 ## One CCCC Installation, Two Implementations
 
-Python and Rust will use the same `0.4.34` product version and `v0.4.34` tag. The
-only supported end-user distribution is `cccc-pair` on PyPI. Its public Python
-launcher keeps Python as the initial default and bundles a private Rust executable
-in wheels for Linux x86-64, Intel and Apple Silicon macOS, and Windows x86-64.
-Other platforms retain the universal Python fallback.
+Python and Rust will use the same `0.4.34` product version and `v0.4.34` tag.
+Linux x86-64, Intel and Apple Silicon macOS, and Windows x86-64 users can install
+the standalone Rust binary from stable GitHub Pages commands without installing
+Rust or Python. The maintained `cccc-pair` distribution keeps Python as its
+initial default and bundles a private Rust executable in its supported platform
+wheels. Other pip platforms retain the universal Python fallback.
 
 Both implementations use the same `CCCC_HOME`, group documents, append-only
 ledgers, actor contracts, daemon IPC model, MCP surface, and Web frontend. Native
@@ -27,8 +28,9 @@ is then published to PyPI once; tags no longer publish a parallel crates.io prod
 implementation and optionally run a command. `cccc status` reports the selected,
 running, and available implementations. The launcher validates exact payload
 version parity before a switch, explicitly replaces the active Web/daemon pair,
-and never silently falls back. `cccc update` updates both implementations as one
-pip product.
+and never silently falls back. In a standalone installation, `cccc update` uses
+the stable website installer; in a pip installation it updates both implementations
+as one pip product.
 
 ## Cline Joins the Runtime Catalog
 
@@ -76,9 +78,9 @@ look older—can no longer cause unread work to be skipped.
   complete authorized events.
 - Existing custom Cline actor commands remain valid. New actors use CCCC's formal
   Cline defaults, and `cccc setup --runtime cline` can repair the MCP entry.
-- A manual unified-release dispatch performs build and verification only. PyPI
-  publication requires a matching pushed `v0.4.34` tag. The standalone Rust
-  candidate workflow is manual-only and never publishes packages.
+- Manual release dispatches perform build and verification only. A matching
+  pushed `v0.4.34` tag publishes the Python artifacts to PyPI and the verified
+  standalone archives, checksums, and installers to GitHub Releases.
 
 ## Why Upgrade
 

--- a/docs/rust-migration.md
+++ b/docs/rust-migration.md
@@ -1,25 +1,51 @@
-# Rust Implementation and Unified Distribution
+# Rust Implementation and Product Distribution
 
-CCCC ships one `cccc-pair` product from PyPI. Python remains the default
-implementation during the migration period. Supported platform wheels also
-contain a private Rust executable with the same product version; users do not
-install a second `cccc` command or manage two entries on `PATH`.
+CCCC now offers a standalone Rust installation for supported platforms while the
+`cccc-pair` Python distribution remains maintained during the migration period.
+Both use the same product version, data contracts, and public `cccc` command.
+Supported Python platform wheels also contain a private Rust executable with the
+same product version.
 
 Prereleases use one canonical product identity and tag such as `v0.4.34-rc1`.
 The Python manifest represents that identity as PEP 440 `0.4.34rc1`, while the
 Cargo workspace uses SemVer `0.4.34-rc1`; release validation normalizes those
 ecosystem-specific spellings before comparing them.
 
-## Install and select an implementation
+## Install and update
 
-Install or upgrade the complete product through one channel:
+Install the standalone Rust binary without a Rust or Python toolchain:
+
+```bash
+# macOS / Linux
+curl -fsSL https://chesterra.github.io/cccc/install.sh | sh
+
+# Windows PowerShell
+irm https://chesterra.github.io/cccc/install.ps1 | iex
+```
+
+The stable GitHub Pages scripts resolve the latest stable GitHub Release, select
+the current platform archive, validate `SHA256SUMS`, and install into a user-owned
+directory. Explicit prereleases remain opt-in through `CCCC_VERSION`, such as
+`0.4.34-rc1`.
+
+The Python distribution remains available during migration:
 
 ```bash
 pip install -U cccc-pair
-cccc update
 ```
 
-The public Python launcher owns implementation selection and product updates:
+In either installation, use:
+
+```bash
+cccc update
+cccc update --check
+```
+
+Standalone Rust installations update through the same GitHub Pages installer.
+The Python launcher continues to update its complete pip product, including the
+private Rust payload on supported platforms.
+
+The public Python launcher also owns implementation selection inside a pip install:
 
 ```bash
 cccc status            # selected, running, and available implementations
@@ -50,11 +76,11 @@ switches both ways, and verifies that Rust `setup` records the stable public
 launcher rather than the private payload path. Unsupported platforms receive the
 universal wheel and report Rust as unavailable.
 
-Cargo remains a workspace development tool. The manual standalone-candidate
-workflow may build archives for engineering diagnostics, but tags no longer
-publish crates.io packages or a second end-user distribution. A future website
-installer can replace the Python launcher only after it preserves the same
-selection, update, rollback, and compatibility guarantees.
+Cargo remains a workspace development tool and the crates stay non-publishable.
+The standalone workflow builds and verifies all four supported archives on manual
+runs. A matching pushed tag additionally publishes those archives, checksums, and
+versioned installers to GitHub Releases; prerelease tags are marked as such so the
+stable installer does not select them implicitly.
 
 ## Data compatibility
 

--- a/docs/vnext/RELEASE.md
+++ b/docs/vnext/RELEASE.md
@@ -1,7 +1,7 @@
 # Releasing CCCC 0.4.x
 
-This repo publishes one PyPI product, **`cccc-pair`** (CLI command: **`cccc`**),
-with Python and Rust implementations on one version line.
+This repo publishes the **`cccc-pair`** Python distribution and standalone Rust
+archives (CLI command: **`cccc`**) on one version line.
 
 ## What the release pipeline produces
 
@@ -15,7 +15,8 @@ The GitHub Actions workflow builds and uploads:
 Platform jobs build, dependency-repair, install, and smoke the private Rust
 payload. A dedicated interop job verifies shared persisted contracts. The
 workflow collects the complete artifact set before one PyPI upload. The manual
-standalone Rust workflow does not publish packages.
+standalone Rust workflow performs verification only; matching pushed tags attach
+the verified archives, checksums, and installers to GitHub Releases.
 
 ## Tag ↔ Version conventions
 

--- a/scripts/install.ps1
+++ b/scripts/install.ps1
@@ -231,6 +231,7 @@ try {
     & (Join-Path $InstallDir "cccc.exe") daemon start *> $null
     if ($LASTEXITCODE -ne 0) { throw "The updated CCCC daemon could not restart" }
   }
+  Set-Content -LiteralPath (Join-Path $InstallDir ".cccc-standalone") -Value "standalone-v1" -Encoding Ascii
   $transactionCommitted = $true
   Remove-Item -LiteralPath $backupDir -Recurse -Force
 

--- a/scripts/install.sh
+++ b/scripts/install.sh
@@ -248,6 +248,7 @@ installed_version=$("$INSTALL_DIR/cccc" --version) || fail "installed cccc faile
 if [ "$daemon_was_running" -eq 1 ]; then
   "$INSTALL_DIR/cccc" daemon start >/dev/null || fail "the updated CCCC daemon could not restart"
 fi
+printf 'standalone-v1\n' > "$INSTALL_DIR/.cccc-standalone"
 transaction_committed=1
 rm -rf "$backup_dir"
 

--- a/scripts/prepare_docs_installers.mjs
+++ b/scripts/prepare_docs_installers.mjs
@@ -1,0 +1,14 @@
+import { chmod, copyFile, mkdir } from "node:fs/promises";
+import { dirname, join } from "node:path";
+import { fileURLToPath } from "node:url";
+
+const root = join(dirname(fileURLToPath(import.meta.url)), "..");
+const publicDir = join(root, "docs", "public");
+
+await mkdir(publicDir, { recursive: true });
+await Promise.all(
+  ["install.sh", "install.ps1"].map((name) =>
+    copyFile(join(root, "scripts", name), join(publicDir, name)),
+  ),
+);
+await chmod(join(publicDir, "install.sh"), 0o755);

--- a/scripts/tests/install_unix.sh
+++ b/scripts/tests/install_unix.sh
@@ -63,6 +63,7 @@ SHELL=/bin/zsh \
 CCCC_RELEASE_BASE_URL="file://$TMP_ROOT/releases" \
 sh "$TMP_ROOT/versioned-install.sh"
 [[ "$("$TMP_ROOT/versioned-home/.local/bin/cccc" --version)" == "cccc $version" ]]
+grep -Fxq 'standalone-v1' "$TMP_ROOT/versioned-home/.local/bin/.cccc-standalone"
 
 HOME="$TMP_ROOT/home with space" \
 SHELL=/bin/bash \
@@ -71,6 +72,7 @@ CCCC_RELEASE_BASE_URL="file://$TMP_ROOT/releases" \
 sh "$ROOT_DIR/scripts/install.sh" > "$TMP_ROOT/bash-install.out"
 
 test -x "$TMP_ROOT/home with space/.local/bin/cccc"
+grep -Fxq 'standalone-v1' "$TMP_ROOT/home with space/.local/bin/.cccc-standalone"
 [[ "$("$TMP_ROOT/home with space/.local/bin/cccc" --version)" == "cccc $version" ]]
 for bash_profile in .bash_profile .bashrc; do
   test "$(grep -Fc '# CCCC' "$TMP_ROOT/home with space/$bash_profile")" -eq 1

--- a/scripts/tests/install_windows.ps1
+++ b/scripts/tests/install_windows.ps1
@@ -105,6 +105,9 @@ try {
   if ((& (Join-Path $versionedInstallDir "cccc.exe") --version | Out-String).Trim() -ne "cccc $realVersion") {
     throw "versioned installer did not use its embedded release version"
   }
+  if ((Get-Content -LiteralPath (Join-Path $versionedInstallDir ".cccc-standalone") -Raw).Trim() -ne "standalone-v1") {
+    throw "versioned installer did not write its standalone marker"
+  }
 
   & (Join-Path $rootDir "scripts\install.ps1") -Version $realVersion -InstallDir $installDir -NoModifyPath
 
@@ -114,6 +117,9 @@ try {
     if ((Get-FileHash $installed).Hash -ne (Get-FileHash (Join-Path $releaseBinaryDir $binary)).Hash) {
       throw "wrong contents for $binary"
     }
+  }
+  if ((Get-Content -LiteralPath (Join-Path $installDir ".cccc-standalone") -Raw).Trim() -ne "standalone-v1") {
+    throw "installer did not write its standalone marker"
   }
   & (Join-Path $rootDir "scripts\install.ps1") -Version $realVersion -InstallDir $installDir -NoModifyPath
   & (Join-Path $rootDir "scripts\install.ps1") -Version $realVersion -InstallDir $installDir

--- a/scripts/tests/verify_release_unix.sh
+++ b/scripts/tests/verify_release_unix.sh
@@ -51,7 +51,8 @@ CCCC_NO_MODIFY_PATH=1 \
 sh "$ARTIFACT_DIR/install.sh"
 
 test -x "$installed"
-test "$(find "$TMP_ROOT/installed" -maxdepth 1 -type f | wc -l | tr -d ' ')" = 1
+test "$(find "$TMP_ROOT/installed" -maxdepth 1 -type f | wc -l | tr -d ' ')" = 2
+grep -Fxq 'standalone-v1' "$TMP_ROOT/installed/.cccc-standalone"
 cmp "$package_dir/cccc" "$installed"
 test "$("$installed" --version)" = "cccc $VERSION"
 

--- a/scripts/tests/verify_release_windows.ps1
+++ b/scripts/tests/verify_release_windows.ps1
@@ -49,8 +49,13 @@ try {
 
   if (-not (Test-Path -LiteralPath $installed -PathType Leaf)) { throw "installer did not install cccc.exe" }
   $installedFiles = @(Get-ChildItem -LiteralPath (Split-Path $installed) -File)
-  if ($installedFiles.Count -ne 1 -or $installedFiles[0].Name -ne "cccc.exe") {
-    throw "installer must install exactly one executable: cccc.exe"
+  $installedNames = @($installedFiles.Name | Sort-Object)
+  if ($installedNames.Count -ne 2 -or
+      (Compare-Object $installedNames @(".cccc-standalone", "cccc.exe"))) {
+    throw "installer must install cccc.exe and its standalone marker"
+  }
+  if ((Get-Content -LiteralPath (Join-Path (Split-Path $installed) ".cccc-standalone") -Raw).Trim() -ne "standalone-v1") {
+    throw "installer wrote an invalid standalone marker"
   }
   if ((Get-FileHash $installed).Hash -ne (Get-FileHash $packageBinary).Hash) {
     throw "installed cccc.exe differs from the release archive"

--- a/tests/test_quality_ci_workflow.py
+++ b/tests/test_quality_ci_workflow.py
@@ -1,5 +1,6 @@
 from __future__ import annotations
 
+import json
 import tomllib
 from pathlib import Path
 
@@ -204,7 +205,7 @@ def test_release_builds_on_314_and_smokes_the_universal_wheel_on_the_311_floor()
     assert floor_setup["with"]["python-version"] == "3.11"
 
 
-def test_one_tag_publishes_one_pypi_product_and_standalone_rust_is_manual_only() -> None:
+def test_one_tag_publishes_pypi_and_matching_standalone_rust_assets() -> None:
     release = _release_workflow()
     rust_candidate = _rust_release_workflow()
 
@@ -224,9 +225,32 @@ def test_one_tag_publishes_one_pypi_product_and_standalone_rust_is_manual_only()
     assert "scripts/publish_rust_crates.sh --publish" not in release_runs
     assert "python -m twine upload" in _runs(release["jobs"]["publish"])
 
-    assert "push" not in rust_candidate["on"]
+    assert rust_candidate["on"]["push"]["tags"] == ["v*"]
     assert "workflow_dispatch" in rust_candidate["on"]
-    assert "publish" not in rust_candidate["jobs"]
+    assert rust_candidate["jobs"]["publish"]["if"] == "github.event_name == 'push'"
+    assert rust_candidate["jobs"]["publish"]["needs"] == "verify"
+    publish_runs = _runs(rust_candidate["jobs"]["publish"])
+    assert "scripts/check_release_versions.py --tag" in publish_runs
+    assert "gh release create" in publish_runs
+    assert "gh release upload" in publish_runs
+    assert "--prerelease" in publish_runs
+
+
+def test_docs_publish_stable_installers_from_the_canonical_scripts() -> None:
+    docs_workflow = yaml.load(
+        (ROOT / ".github/workflows/docs.yml").read_text(encoding="utf-8"),
+        Loader=yaml.BaseLoader,
+    )
+    paths = set(docs_workflow["on"]["push"]["paths"])
+    package = json.loads((ROOT / "docs/package.json").read_text(encoding="utf-8"))
+
+    assert {
+        "scripts/install.sh",
+        "scripts/install.ps1",
+        "scripts/prepare_docs_installers.mjs",
+    } <= paths
+    assert package["scripts"]["prebuild"] == "npm run prepare:installers"
+    assert package["scripts"]["prepare:installers"] == "node ../scripts/prepare_docs_installers.mjs"
 
 
 def test_rust_workspace_cannot_create_a_second_registry_distribution() -> None:
@@ -239,5 +263,7 @@ def test_rust_workspace_cannot_create_a_second_registry_distribution() -> None:
         assert package.get("publish") is False, manifest
 
     assert not (ROOT / "scripts/publish_rust_crates.sh").exists()
-    rust_main = (ROOT / "crates/cccc-cli/src/main.rs").read_text(encoding="utf-8")
-    assert "the Rust implementation cannot update independently" in rust_main
+    rust_update = (ROOT / "crates/cccc-cli/src/commands/update.rs").read_text(encoding="utf-8")
+    assert "https://chesterra.github.io/cccc/install.sh" in rust_update
+    assert ".cccc-standalone" in rust_update
+    assert "managed by another installation" in rust_update


### PR DESCRIPTION
## What changed

- publish stable `install.sh` and `install.ps1` endpoints from the GitHub Pages site
- publish verified standalone Rust archives, checksums, and versioned installers on matching release tags
- make standalone `cccc update` reuse the website installer while keeping wheel-private Rust payloads owned by pip
- document macOS, Linux, Windows, and explicit prerelease installation commands
- extend installer, release, docs, and workflow contract tests

## Why

Users should be able to install the Rust implementation with one stable command and without a local Rust or Python toolchain. The stable script must be backed by verified GitHub Release assets, and a standalone installation must retain a safe update path.

## Validation

- `npm -C docs run build` and installer output comparisons
- `bash scripts/tests/install_unix.sh`
- `bash scripts/tests/release_assets.sh`
- `pytest -q tests/test_quality_ci_workflow.py`
- `cargo fmt --all --check`
- `cargo clippy -p cccc --all-targets --locked -- -D warnings`
- `cargo test -p cccc --locked`
- standalone `cccc update --check` smoke
- `graphify update .`

Windows release compilation and PowerShell installation remain covered by the existing `windows-latest` release matrix. A macOS-hosted cross-check cannot compile native TLS dependencies without the Windows SDK.