### PR TITLE
fix: recover Rust runtimes after restart

### DIFF
--- a/crates/cccc-core/src/group_scope.rs
+++ b/crates/cccc-core/src/group_scope.rs
@@ -17,6 +17,8 @@ pub fn resolve_attached_scope<'a>(group: &'a GroupDoc, reference: &str) -> Optio
 }
 
 pub fn normalize_actor_scope_keys(group: &mut GroupDoc) -> usize {
+    let active_scope_key =
+        resolve_attached_scope(group, &group.active_scope_key).map(|scope| scope.scope_key.clone());
     let replacements = group
         .actors
         .iter()
@@ -26,8 +28,10 @@ pub fn normalize_actor_scope_keys(group: &mut GroupDoc) -> usize {
             if reference.is_empty() {
                 return None;
             }
-            let scope = resolve_attached_scope(group, reference)?;
-            (scope.scope_key != reference).then(|| (index, scope.scope_key.clone()))
+            let scope_key = resolve_attached_scope(group, reference)
+                .map(|scope| scope.scope_key.clone())
+                .or_else(|| active_scope_key.clone())?;
+            (scope_key != reference).then_some((index, scope_key))
         })
         .collect::<Vec<_>>();
     for (index, scope_key) in &replacements {
@@ -122,6 +126,11 @@ fn detach_with(
                     .map(|scope| scope.scope_key.clone())
                     .unwrap_or_default();
             }
+            for actor in &mut group.actors {
+                if actor.default_scope_key == scope_key {
+                    actor.default_scope_key.clone_from(&group.active_scope_key);
+                }
+            }
             Ok(group.clone())
         },
         update_registry,
@@ -196,6 +205,67 @@ mod tests {
         assert_eq!(normalize_actor_scope_keys(&mut group), 1);
         assert_eq!(group.actors[0].default_scope_key, "s_project");
         assert_eq!(normalize_actor_scope_keys(&mut group), 0);
+    }
+
+    #[test]
+    fn stale_actor_scope_keys_fall_back_to_the_active_scope() {
+        let temp = tempfile::tempdir().expect("tempdir");
+        let scope_path = temp.path().join("project");
+        std::fs::create_dir(&scope_path).expect("project");
+        let mut group =
+            GroupStore::new(HomeLayout::from_path(temp.path().join("home")).expect("home"))
+                .expect("store")
+                .create("scope repair", "")
+                .expect("group");
+        group.scopes.push(Scope {
+            scope_key: "s_active".into(),
+            url: scope_path.to_string_lossy().into_owned(),
+            label: "project".into(),
+            git_remote: String::new(),
+        });
+        group.active_scope_key = "s_active".into();
+        let mut actor = cccc_contracts::Actor::new("peer");
+        actor.default_scope_key = "s_detached".into();
+        group.actors.push(actor);
+
+        assert_eq!(normalize_actor_scope_keys(&mut group), 1);
+        assert_eq!(group.actors[0].default_scope_key, "s_active");
+    }
+
+    #[test]
+    fn detach_reassigns_actor_scope_to_the_remaining_active_scope() {
+        let temp = tempfile::tempdir().expect("tempdir");
+        let home = HomeLayout::from_path(temp.path().join("home")).expect("home");
+        let store = GroupStore::new(home).expect("store");
+        let group = store.create("scope detach", "").expect("group");
+        store
+            .mutate(&group.group_id, |group| {
+                group.scopes = vec![
+                    Scope {
+                        scope_key: "s_old".into(),
+                        url: temp.path().join("old").to_string_lossy().into_owned(),
+                        label: "old".into(),
+                        git_remote: String::new(),
+                    },
+                    Scope {
+                        scope_key: "s_next".into(),
+                        url: temp.path().join("next").to_string_lossy().into_owned(),
+                        label: "next".into(),
+                        git_remote: String::new(),
+                    },
+                ];
+                group.active_scope_key = "s_old".into();
+                let mut actor = cccc_contracts::Actor::new("peer");
+                actor.default_scope_key = "s_old".into();
+                group.actors.push(actor);
+                Ok(())
+            })
+            .expect("configure group");
+
+        let detached = detach_with(&store, &group.group_id, "s_old", |_| Ok(())).expect("detach");
+
+        assert_eq!(detached.active_scope_key, "s_next");
+        assert_eq!(detached.actors[0].default_scope_key, "s_next");
     }
 
     #[test]

--- a/crates/cccc-daemon/src/ops/actor_runtime.rs
+++ b/crates/cccc-daemon/src/ops/actor_runtime.rs
@@ -1,4 +1,4 @@
-use cccc_contracts::{Actor, ActorRuntime, RunnerKind, RuntimeStateSource};
+use cccc_contracts::{Actor, ActorRuntime, RunnerKind};
 use cccc_core::{GroupDoc, GroupStore, HomeLayout};
 use cccc_runtime::SessionStatus;
 use std::path::PathBuf;
@@ -93,7 +93,6 @@ fn start(home: &HomeLayout, group: &GroupDoc, actor: &Actor) -> Result<SessionSt
                 &actor.id,
                 &cwd,
                 &base_command,
-                actor.runtime_state_source == RuntimeStateSource::AppServer,
             )
         }
         (ActorRuntime::Grok, cccc_contracts::RunnerKind::Pty) => {

--- a/crates/cccc-daemon/src/ops/actor_runtime/resume_verification.rs
+++ b/crates/cccc-daemon/src/ops/actor_runtime/resume_verification.rs
@@ -3,8 +3,30 @@ use cccc_core::{GroupDoc, HomeLayout};
 use cccc_runtime::SessionStatus;
 use std::collections::BTreeMap;
 use std::path::PathBuf;
+use std::time::{Duration, Instant};
 
 use super::{hook_launch, runtime_session, schedule_capture};
+
+const CAPTURE_DELAY: Duration = Duration::from_secs(2);
+const FAILURE_MONITOR_DURATION: Duration = Duration::from_secs(20);
+const POLL_INTERVAL: Duration = Duration::from_millis(50);
+
+#[derive(Clone, Copy)]
+struct VerificationTiming {
+    capture_delay: Duration,
+    monitor_duration: Duration,
+    poll_interval: Duration,
+}
+
+impl Default for VerificationTiming {
+    fn default() -> Self {
+        Self {
+            capture_delay: CAPTURE_DELAY,
+            monitor_duration: FAILURE_MONITOR_DURATION,
+            poll_interval: POLL_INTERVAL,
+        }
+    }
+}
 
 pub(super) fn schedule(
     home: HomeLayout,
@@ -15,43 +37,125 @@ pub(super) fn schedule(
     base_command: Vec<String>,
     resumed_status: SessionStatus,
 ) {
+    schedule_with_timing(
+        home,
+        group,
+        actor,
+        cwd,
+        env,
+        base_command,
+        resumed_status,
+        VerificationTiming::default(),
+    );
+}
+
+#[allow(clippy::too_many_arguments)]
+fn schedule_with_timing(
+    home: HomeLayout,
+    group: GroupDoc,
+    actor: Actor,
+    cwd: PathBuf,
+    env: BTreeMap<String, String>,
+    base_command: Vec<String>,
+    resumed_status: SessionStatus,
+    timing: VerificationTiming,
+) {
     let _ = std::thread::Builder::new()
         .name(format!(
             "cccc-resume-verify:{}:{}",
             group.group_id, actor.id
         ))
         .spawn(move || {
-            let deadline = std::time::Instant::now() + std::time::Duration::from_secs(2);
-            let mut error = None;
-            while std::time::Instant::now() < deadline {
-                let Ok(current) = cccc_runtime::status(&group.group_id, &actor.id) else {
-                    return;
+            let started = Instant::now();
+            let capture_at = started + timing.capture_delay;
+            let deadline = started + timing.monitor_duration.max(timing.capture_delay);
+            let mut capture_scheduled = false;
+            let error = loop {
+                let current = match cccc_runtime::status(&group.group_id, &actor.id) {
+                    Ok(current) => current,
+                    Err(cccc_runtime::RuntimeError::NotFound(_, _)) => {
+                        break Some("provider resume process disappeared early".to_owned());
+                    }
+                    Err(error) => {
+                        tracing::warn!(
+                            group_id = %group.group_id,
+                            actor_id = %actor.id,
+                            %error,
+                            "failed to inspect resumed actor"
+                        );
+                        return;
+                    }
                 };
                 if current.started_at != resumed_status.started_at {
                     return;
                 }
                 if !current.running {
-                    error = Some("provider resume process exited early".to_owned());
-                    break;
+                    break Some("provider resume process exited early".to_owned());
                 }
                 if let Some(message) = runtime_session::resume_failure(&group.group_id, &actor.id) {
-                    error = Some(message);
-                    break;
+                    break Some(message);
                 }
-                std::thread::sleep(std::time::Duration::from_millis(50));
-            }
+                let now = Instant::now();
+                if !capture_scheduled && now >= capture_at {
+                    schedule_capture(
+                        &home,
+                        &group,
+                        &actor,
+                        cwd.clone(),
+                        base_command.clone(),
+                        &resumed_status,
+                    );
+                    capture_scheduled = true;
+                }
+                if now >= deadline {
+                    break None;
+                }
+                std::thread::sleep(timing.poll_interval);
+            };
 
             let Some(error) = error else {
-                schedule_capture(&home, &group, &actor, cwd, base_command, &resumed_status);
+                if !capture_scheduled {
+                    schedule_capture(&home, &group, &actor, cwd, base_command, &resumed_status);
+                }
                 return;
             };
-            let stopped = cccc_runtime::stop_if_started_at(
+            if crate::runtime_start_gate::permit(&home).is_err() {
+                return;
+            }
+            let stopped = match cccc_runtime::stop_if_started_at(
                 &group.group_id,
                 &actor.id,
                 &resumed_status.started_at,
-            );
-            if !matches!(stopped, Ok(Some(_))) {
-                return;
+            ) {
+                Ok(stopped) => stopped,
+                Err(stop_error) => {
+                    tracing::warn!(
+                        group_id = %group.group_id,
+                        actor_id = %actor.id,
+                        %stop_error,
+                        "failed to stop rejected resumed actor"
+                    );
+                    return;
+                }
+            };
+            if stopped.is_none() {
+                match cccc_runtime::status(&group.group_id, &actor.id) {
+                    Ok(current)
+                        if current.running || current.started_at != resumed_status.started_at =>
+                    {
+                        return;
+                    }
+                    Ok(_) | Err(cccc_runtime::RuntimeError::NotFound(_, _)) => {}
+                    Err(status_error) => {
+                        tracing::warn!(
+                            group_id = %group.group_id,
+                            actor_id = %actor.id,
+                            %status_error,
+                            "failed to verify rejected resumed actor ownership"
+                        );
+                        return;
+                    }
+                }
             }
             super::super::runtime_hook_session::revoke(&group.group_id, &actor.id);
             if let Err(persist_error) =
@@ -89,3 +193,7 @@ pub(super) fn schedule(
             }
         });
 }
+
+#[cfg(all(test, unix))]
+#[path = "resume_verification_tests.rs"]
+mod tests;

--- a/crates/cccc-daemon/src/ops/actor_runtime/resume_verification_tests.rs
+++ b/crates/cccc-daemon/src/ops/actor_runtime/resume_verification_tests.rs
@@ -1,0 +1,90 @@
+use super::*;
+use cccc_contracts::{ActorRuntime, RunnerKind};
+use cccc_core::{GroupStore, actors};
+use cccc_runtime::LaunchSpec;
+use serde_json::json;
+
+#[test]
+fn delayed_resume_rejection_starts_a_fresh_process() {
+    let temp = tempfile::tempdir().expect("tempdir");
+    let home = HomeLayout::from_path(temp.path().join("home")).expect("home");
+    let store = GroupStore::new(home.clone()).expect("store");
+    let created = store.create("resume fallback", "").expect("group");
+    let cwd = temp.path().join("repo");
+    std::fs::create_dir(&cwd).expect("cwd");
+    let fresh_command = vec!["sh".into(), "-c".into(), "sleep 5".into()];
+    let actor = store
+        .mutate(&created.group_id, |group| {
+            let mut actor = Actor::new("peer1");
+            actor.runtime = ActorRuntime::Custom;
+            actor.runner = RunnerKind::Pty;
+            actor.command = fresh_command.clone();
+            actors::add(group, actor)
+        })
+        .expect("actor");
+    let group = store.load(&created.group_id).expect("group");
+    let session_dir = store
+        .state_dir(&group.group_id)
+        .expect("state dir")
+        .join("runtime_sessions");
+    std::fs::create_dir_all(&session_dir).expect("session dir");
+    cccc_core::fs::write_json(
+        &session_dir.join("peer1.json"),
+        &json!({
+            "runtime":"codex",
+            "status":"usable",
+            "resume_eligible":true,
+            "failure_count":0
+        }),
+    )
+    .expect("resume metadata");
+
+    let resumed_status = cccc_runtime::start(LaunchSpec {
+        group_id: group.group_id.clone(),
+        actor_id: actor.id.clone(),
+        runner: RunnerKind::Pty,
+        command: vec![
+            "sh".into(),
+            "-c".into(),
+            "sleep 0.15; printf 'ERROR: No saved session found with ID stale\\n'; sleep 5".into(),
+        ],
+        cwd: cwd.clone(),
+        env: BTreeMap::new(),
+        cols: 120,
+        rows: 40,
+    })
+    .expect("resumed process");
+
+    schedule_with_timing(
+        home.clone(),
+        group.clone(),
+        actor.clone(),
+        cwd,
+        BTreeMap::new(),
+        fresh_command,
+        resumed_status.clone(),
+        VerificationTiming {
+            capture_delay: Duration::from_millis(50),
+            monitor_duration: Duration::from_secs(1),
+            poll_interval: Duration::from_millis(20),
+        },
+    );
+
+    let deadline = Instant::now() + Duration::from_secs(3);
+    let fresh = loop {
+        if let Ok(status) = cccc_runtime::status(&group.group_id, &actor.id)
+            && status.running
+            && status.started_at != resumed_status.started_at
+        {
+            break status;
+        }
+        assert!(Instant::now() < deadline, "fresh fallback did not start");
+        std::thread::sleep(Duration::from_millis(20));
+    };
+    let stored: serde_json::Value =
+        cccc_core::fs::read_json(&session_dir.join("peer1.json")).expect("stored metadata");
+    assert_eq!(stored["status"], "resume_failed");
+    assert_eq!(stored["resume_eligible"], false);
+    assert_eq!(fresh.actor_id, "peer1");
+    cccc_runtime::stop(&group.group_id, &actor.id).expect("stop fresh process");
+}

--- a/crates/cccc-daemon/src/ops/actor_runtime_tests.rs
+++ b/crates/cccc-daemon/src/ops/actor_runtime_tests.rs
@@ -50,6 +50,7 @@ fn restores_enabled_actors_for_persisted_running_groups() {
             });
             group.active_scope_key = "s_project".into();
             let mut actor = Actor::new("peer1");
+            actor.default_scope_key = "s_detached".into();
             actor.runtime = ActorRuntime::Custom;
             actor.runner = RunnerKind::Pty;
             actor.command = vec!["sh".into(), "-c".into(), "sleep 5".into()];
@@ -62,6 +63,10 @@ fn restores_enabled_actors_for_persisted_running_groups() {
 
     assert!(runtime_restore::restore_running(&home).is_ok());
     assert!(actor_runtime::status(&group_id, "peer1").is_some_and(|status| status.running));
+    assert_eq!(
+        store.load(&group_id).expect("restored group").actors[0].default_scope_key,
+        "s_project"
+    );
     cccc_runtime::stop(&group_id, "peer1").expect("stop");
 }
 

--- a/crates/cccc-daemon/src/ops/runtime_session.rs
+++ b/crates/cccc-daemon/src/ops/runtime_session.rs
@@ -36,7 +36,6 @@ pub fn prepare_codex_command(
     actor_id: &str,
     cwd: &Path,
     base_command: &[String],
-    allow_thread_migration: bool,
 ) -> PreparedCommand {
     let fresh = || PreparedCommand {
         command: base_command.to_vec(),
@@ -62,17 +61,23 @@ pub fn prepare_codex_command(
 
     let provider_session_id = string(&document, "provider_session_id");
     let provider_thread_id = string(&document, "provider_thread_id");
-    let session_id = if valid_session_id(&provider_session_id)
-        && string(&document, "command_fingerprint") == command_fingerprint(base_command)
-    {
-        provider_session_id
-    } else if allow_thread_migration && valid_session_id(&provider_thread_id) {
-        // Python's Codex app-server stored a thread id with an app-server
-        // command fingerprint. Codex CLI accepts that UUID through `resume`.
-        provider_thread_id
-    } else {
+    if provider_session_id.is_empty() && !provider_thread_id.is_empty() {
+        if let Err(error) = mark_resume_failed(
+            home,
+            group_id,
+            actor_id,
+            "saved app-server thread cannot be resumed by Codex CLI; starting a fresh session",
+        ) {
+            tracing::warn!(%error, %group_id, %actor_id, "failed to invalidate app-server resume metadata");
+        }
         return fresh();
-    };
+    }
+    if !valid_session_id(&provider_session_id)
+        || string(&document, "command_fingerprint") != command_fingerprint(base_command)
+    {
+        return fresh();
+    }
+    let session_id = provider_session_id;
 
     let now = utc_now();
     document.insert("last_resume_attempt_at".into(), json!(now));
@@ -119,9 +124,14 @@ pub fn schedule_codex_session_capture(
 
 pub fn resume_failure(group_id: &str, actor_id: &str) -> Option<String> {
     let history = cccc_runtime::history(group_id, actor_id, None, 64_000).ok()?;
-    let plain = strip_ansi(&history.data).to_ascii_lowercase();
+    resume_failure_marker(&history.data).map(str::to_owned)
+}
+
+fn resume_failure_marker(text: &str) -> Option<&'static str> {
+    let plain = strip_ansi(text).to_ascii_lowercase();
     [
         "no conversation found",
+        "no saved session found",
         "conversation not found",
         "session not found",
         "thread not found",
@@ -132,7 +142,7 @@ pub fn resume_failure(group_id: &str, actor_id: &str) -> Option<String> {
     ]
     .iter()
     .find(|marker| plain.contains(**marker))
-    .map(|marker| (*marker).to_owned())
+    .copied()
 }
 
 pub fn mark_resume_failed(
@@ -450,7 +460,7 @@ mod tests {
         ]);
         write(&home, &group_id, "peer1", &document).expect("write");
 
-        let prepared = prepare_codex_command(&home, &group_id, "peer1", &cwd, &base, false);
+        let prepared = prepare_codex_command(&home, &group_id, "peer1", &cwd, &base);
 
         assert_eq!(prepared.resumed_session_id.as_deref(), Some(session_id));
         assert_eq!(
@@ -460,7 +470,7 @@ mod tests {
     }
 
     #[test]
-    fn migrates_python_app_server_thread_without_reusing_its_fingerprint() {
+    fn starts_fresh_for_python_app_server_thread_metadata() {
         let (_temp, home, group_id, cwd) = fixture();
         let thread_id = "019f4055-4231-77b0-b559-8de345f57f5e";
         let base = command();
@@ -479,9 +489,18 @@ mod tests {
         ]);
         write(&home, &group_id, "foreman", &document).expect("write");
 
-        let prepared = prepare_codex_command(&home, &group_id, "foreman", &cwd, &base, true);
+        let prepared = prepare_codex_command(&home, &group_id, "foreman", &cwd, &base);
 
-        assert_eq!(prepared.resumed_session_id.as_deref(), Some(thread_id));
+        assert!(prepared.resumed_session_id.is_none());
+        assert_eq!(prepared.command, base);
+        let stored = read(&home, &group_id, "foreman").expect("stored metadata");
+        assert_eq!(stored["status"], "resume_failed");
+        assert_eq!(stored["resume_eligible"], false);
+        assert!(
+            stored["last_resume_error"]
+                .as_str()
+                .is_some_and(|error| error.contains("app-server thread"))
+        );
     }
 
     #[test]
@@ -505,7 +524,7 @@ mod tests {
         ]);
         write(&home, &group_id, "peer1", &document).expect("write");
 
-        let prepared = prepare_codex_command(&home, &group_id, "peer1", &cwd, &base, false);
+        let prepared = prepare_codex_command(&home, &group_id, "peer1", &cwd, &base);
 
         assert!(prepared.resumed_session_id.is_none());
         assert_eq!(prepared.command, base);
@@ -517,6 +536,16 @@ mod tests {
         assert_eq!(
             parse_codex_session_id(text).as_deref(),
             Some("019eece8-8c6d-7811-a700-26593825ae2d")
+        );
+    }
+
+    #[test]
+    fn detects_codex_no_saved_session_resume_failure() {
+        assert_eq!(
+            resume_failure_marker(
+                "ERROR: No saved session found with ID 019eece8-8c6d-7811-a700-26593825ae2d"
+            ),
+            Some("no saved session found")
         );
     }
 


### PR DESCRIPTION
## Summary

- Repair stale actor scope assignments to the active attached scope during daemon restore.
- Reassign actors when their scope is detached so future restarts remain valid.
- Stop treating Python app-server thread IDs as Codex CLI session IDs.
- Monitor resumed CLI sessions for delayed failures and automatically start a fresh session when resume is rejected.

## Root cause

Python app-server metadata stores a provider thread ID, but the Rust PTY implementation passed that ID to `codex resume` as though it were a CLI session ID. Codex then exited with `No saved session found`. The previous two-second verifier could miss delayed terminal output, leaving the actor offline.

Separately, actors could retain a detached `default_scope_key`. Runtime restoration then failed before launch with `scope_not_attached`.

## Impact

Persisted running groups now recover their enabled actors after a daemon restart. Compatible Codex CLI sessions still resume normally; incompatible or rejected resume state falls back to a fresh process. Existing groups with stale actor scope keys are repaired and persisted automatically.

## Validation

- `cargo test -p cccc-pair-core -p cccc-pair-daemon`
- `cargo clippy -p cccc-pair-core -p cccc-pair-daemon --all-targets -- -D warnings`
- `cargo build --release -p cccc`
- Pre-commit impacted checks: 110 core and 147 daemon unit tests passed
- `graphify update .`
