### PR TITLE
ci: stabilize and separate verification pipelines

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -1,0 +1,11 @@
+version: 2
+
+updates:
+  - package-ecosystem: github-actions
+    directory: /
+    schedule:
+      interval: weekly
+    groups:
+      github-actions:
+        patterns:
+          - "*"

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -4,12 +4,13 @@ on:
   push:
     branches: [main, rust]
   pull_request:
+  workflow_dispatch:
 
 permissions:
   contents: read
 
 concurrency:
-  group: ci-${{ github.workflow }}-${{ github.ref }}
+  group: ci-${{ github.event.pull_request.number || github.ref }}
   cancel-in-progress: true
 
 jobs:
@@ -18,10 +19,10 @@ jobs:
     timeout-minutes: 15
     steps:
       - name: Checkout
-        uses: actions/checkout@v4
+        uses: actions/checkout@v7
 
       - name: Set up Python
-        uses: actions/setup-python@v5
+        uses: actions/setup-python@v7
         with:
           python-version: "3.14"
           cache: pip
@@ -47,10 +48,10 @@ jobs:
     timeout-minutes: 15
     steps:
       - name: Checkout
-        uses: actions/checkout@v4
+        uses: actions/checkout@v7
 
       - name: Set up Node
-        uses: actions/setup-node@v4
+        uses: actions/setup-node@v7
         with:
           node-version: "24.19.0"
           cache: npm
@@ -69,7 +70,7 @@ jobs:
         run: npm -C web run build
 
       - name: Upload Web bundle
-        uses: actions/upload-artifact@v4
+        uses: actions/upload-artifact@v7
         with:
           name: bundled-web
           path: web/dist
@@ -85,16 +86,16 @@ jobs:
         shard: [0, 1, 2, 3]
     steps:
       - name: Checkout
-        uses: actions/checkout@v4
+        uses: actions/checkout@v7
 
       - name: Download Web bundle
-        uses: actions/download-artifact@v4
+        uses: actions/download-artifact@v8
         with:
           name: bundled-web
           path: src/cccc/ports/web/dist
 
       - name: Set up Python
-        uses: actions/setup-python@v5
+        uses: actions/setup-python@v7
         with:
           python-version: "3.14"
           cache: pip
@@ -121,10 +122,10 @@ jobs:
         python-version: ["3.11", "3.12", "3.13"]
     steps:
       - name: Checkout
-        uses: actions/checkout@v4
+        uses: actions/checkout@v7
 
       - name: Set up Python ${{ matrix.python-version }}
-        uses: actions/setup-python@v5
+        uses: actions/setup-python@v7
         with:
           python-version: ${{ matrix.python-version }}
           cache: pip
@@ -168,16 +169,16 @@ jobs:
     timeout-minutes: 25
     steps:
       - name: Checkout
-        uses: actions/checkout@v4
+        uses: actions/checkout@v7
 
       - name: Download Web bundle
-        uses: actions/download-artifact@v4
+        uses: actions/download-artifact@v8
         with:
           name: bundled-web
           path: src/cccc/ports/web/dist
 
       - name: Set up Python
-        uses: actions/setup-python@v5
+        uses: actions/setup-python@v7
         with:
           python-version: "3.14"
           cache: pip
@@ -237,16 +238,16 @@ jobs:
     timeout-minutes: 20
     steps:
       - name: Checkout
-        uses: actions/checkout@v4
+        uses: actions/checkout@v7
 
       - name: Download Web bundle
-        uses: actions/download-artifact@v4
+        uses: actions/download-artifact@v8
         with:
           name: bundled-web
           path: web/dist
 
       - name: Set up Python
-        uses: actions/setup-python@v5
+        uses: actions/setup-python@v7
         with:
           python-version: "3.14"
 
@@ -262,44 +263,13 @@ jobs:
           tests/test_socket_special_ops.py tests/test_windows_pty_backend.py
           tests/test_installation_diagnostics.py tests/test_system_cmds_doctor.py
 
-  windows-installer:
-    # Installer/PATH ownership checks need a native release build; keep them
-    # off the PR critical path and verify them when changes land on a branch.
-    if: github.event_name == 'push'
-    needs: web
-    runs-on: windows-latest
-    timeout-minutes: 40
-    steps:
-      - name: Checkout
-        uses: actions/checkout@v4
-
-      - name: Download Web bundle
-        uses: actions/download-artifact@v4
-        with:
-          name: bundled-web
-          path: web/dist
-
-      - name: Set up Rust
-        uses: dtolnay/rust-toolchain@1.88.0
-
-      - name: Cache Rust build
-        uses: Swatinem/rust-cache@v2
-
-      - name: Build native Windows installer fixture
-        run: cargo build --release --locked -p cccc --bin cccc
-
-      - name: Test Windows installer ownership and PATH handling
-        shell: pwsh
-        timeout-minutes: 15
-        run: scripts/tests/install_windows.ps1
-
   rust-lint:
     needs: web
     runs-on: ubuntu-latest
     timeout-minutes: 15
     steps:
-      - uses: actions/checkout@v4
-      - uses: actions/download-artifact@v4
+      - uses: actions/checkout@v7
+      - uses: actions/download-artifact@v8
         with:
           name: bundled-web
           path: web/dist
@@ -317,8 +287,8 @@ jobs:
     runs-on: ubuntu-latest
     timeout-minutes: 45
     steps:
-      - uses: actions/checkout@v4
-      - uses: actions/download-artifact@v4
+      - uses: actions/checkout@v7
+      - uses: actions/download-artifact@v8
         with:
           name: bundled-web
           path: web/dist
@@ -331,34 +301,32 @@ jobs:
       - name: Test Rust workspace
         run: |
           # The dedicated interop job owns tests that execute src/cccc. Keep
-          # this Rust-only job independent of a Python installation.
+          # this Rust-only job independent of a Python installation. Process
+          # lifecycle tests run serially in their own job below because they
+          # spawn and stop a combined daemon/Web process.
           cargo test --workspace --exclude cccc-pair-daemon --locked -- \
-            --skip python_interop_
+            --skip python_interop_ \
+            --skip daemon_self_launch::
           cargo test --package cccc-pair-daemon --locked -- \
             --test-threads=1 \
             --skip python_interop_
 
-  rust-dist:
-    # The release distribution smoke needs a full release build; keep it off
-    # the PR critical path and verify it when changes land on a branch.
-    if: github.event_name == 'push'
+  rust-process-lifecycle:
     needs: web
     runs-on: ubuntu-latest
-    timeout-minutes: 30
+    timeout-minutes: 15
     steps:
-      - uses: actions/checkout@v4
-      - uses: actions/download-artifact@v4
+      - uses: actions/checkout@v7
+      - uses: actions/download-artifact@v8
         with:
           name: bundled-web
           path: web/dist
       - uses: dtolnay/rust-toolchain@1.88.0
       - uses: Swatinem/rust-cache@v2
-      - name: Build and verify Rust distribution
-        run: |
-          cargo build --workspace --release --locked
-          scripts/tests/install_real_unix.sh target/release/cccc
-          target/release/cccc --version
-          bash scripts/tests/smoke_rust_replacement.sh target/release/cccc
+      - name: Test combined daemon and Web process lifecycle serially
+        run: >-
+          cargo test --package cccc --test integration --locked
+          daemon_self_launch:: -- --test-threads=1
 
   interop:
     needs: web
@@ -368,16 +336,16 @@ jobs:
       CCCC_TEST_PYTHON: python
     steps:
       - name: Checkout
-        uses: actions/checkout@v4
+        uses: actions/checkout@v7
 
       - name: Download Web bundle
-        uses: actions/download-artifact@v4
+        uses: actions/download-artifact@v8
         with:
           name: bundled-web
           path: web/dist
 
       - name: Set up Python
-        uses: actions/setup-python@v5
+        uses: actions/setup-python@v7
         with:
           python-version: "3.14"
 
@@ -402,3 +370,38 @@ jobs:
           cargo test -p cccc-pair-core --test ledger_python_interop --locked
           cargo test -p cccc-pair-core --test shared_integration_state_interop --locked
           cargo test -p cccc-pair-daemon --test python_storage_interop --locked -- --test-threads=1
+
+  ci-required:
+    if: always()
+    needs:
+      - quality
+      - web
+      - python-tests
+      - python-compat
+      - package
+      - windows-smoke
+      - rust-lint
+      - rust-test
+      - rust-process-lifecycle
+      - interop
+    runs-on: ubuntu-latest
+    timeout-minutes: 5
+    steps:
+      - name: Verify required CI jobs
+        env:
+          NEEDS_CONTEXT: ${{ toJSON(needs) }}
+        shell: bash
+        run: |
+          failures="$(
+            jq -r '
+              to_entries[]
+              | select(.value.result != "success")
+              | "\(.key)=\(.value.result)"
+            ' <<<"$NEEDS_CONTEXT"
+          )"
+          if [[ -n "$failures" ]]; then
+            echo "Required CI jobs did not succeed:"
+            echo "$failures"
+            exit 1
+          fi
+          echo "All required CI jobs succeeded."

--- a/.github/workflows/nightly.yml
+++ b/.github/workflows/nightly.yml
@@ -24,10 +24,10 @@ jobs:
         python-version: ["3.11"]
     steps:
       - name: Checkout
-        uses: actions/checkout@v4
+        uses: actions/checkout@v7
 
       - name: Set up Python ${{ matrix.python-version }}
-        uses: actions/setup-python@v5
+        uses: actions/setup-python@v7
         with:
           python-version: ${{ matrix.python-version }}
           cache: pip

--- a/.github/workflows/post-merge.yml
+++ b/.github/workflows/post-merge.yml
@@ -1,0 +1,121 @@
+name: Post-merge
+
+on:
+  push:
+    branches: [main, rust]
+  workflow_dispatch:
+
+permissions:
+  contents: read
+
+concurrency:
+  group: post-merge-${{ github.ref }}
+  cancel-in-progress: true
+
+jobs:
+  web-bundle:
+    runs-on: ubuntu-latest
+    timeout-minutes: 15
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v7
+
+      - name: Set up Node
+        uses: actions/setup-node@v7
+        with:
+          node-version: "24.19.0"
+          cache: npm
+          cache-dependency-path: web/package-lock.json
+
+      - name: Install Web dependencies
+        run: npm ci --prefix web
+
+      - name: Build Web bundle
+        run: npm -C web run build
+
+      - name: Upload Web bundle
+        uses: actions/upload-artifact@v7
+        with:
+          name: post-merge-web
+          path: web/dist
+          if-no-files-found: error
+
+  rust-dist:
+    needs: web-bundle
+    runs-on: ubuntu-latest
+    timeout-minutes: 30
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v7
+
+      - name: Download Web bundle
+        uses: actions/download-artifact@v8
+        with:
+          name: post-merge-web
+          path: web/dist
+
+      - name: Set up Rust
+        uses: dtolnay/rust-toolchain@1.88.0
+
+      - name: Cache Rust build
+        uses: Swatinem/rust-cache@v2
+
+      - name: Build and verify Rust distribution
+        run: |
+          cargo build --workspace --release --locked
+          scripts/tests/install_real_unix.sh target/release/cccc
+          target/release/cccc --version
+          bash scripts/tests/smoke_rust_replacement.sh target/release/cccc
+
+  windows-installer:
+    needs: web-bundle
+    runs-on: windows-latest
+    timeout-minutes: 40
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v7
+
+      - name: Download Web bundle
+        uses: actions/download-artifact@v8
+        with:
+          name: post-merge-web
+          path: web/dist
+
+      - name: Set up Rust
+        uses: dtolnay/rust-toolchain@1.88.0
+
+      - name: Cache Rust build
+        uses: Swatinem/rust-cache@v2
+
+      - name: Build native Windows installer fixture
+        run: cargo build --release --locked -p cccc --bin cccc
+
+      - name: Test Windows installer ownership and PATH handling
+        shell: pwsh
+        timeout-minutes: 15
+        run: scripts/tests/install_windows.ps1
+
+  post-merge-required:
+    if: always()
+    needs: [web-bundle, rust-dist, windows-installer]
+    runs-on: ubuntu-latest
+    timeout-minutes: 5
+    steps:
+      - name: Verify post-merge jobs
+        env:
+          NEEDS_CONTEXT: ${{ toJSON(needs) }}
+        shell: bash
+        run: |
+          failures="$(
+            jq -r '
+              to_entries[]
+              | select(.value.result != "success")
+              | "\(.key)=\(.value.result)"
+            ' <<<"$NEEDS_CONTEXT"
+          )"
+          if [[ -n "$failures" ]]; then
+            echo "Post-merge jobs did not succeed:"
+            echo "$failures"
+            exit 1
+          fi
+          echo "All post-merge jobs succeeded."

--- a/.github/workflows/release-rust.yml
+++ b/.github/workflows/release-rust.yml
@@ -15,11 +15,11 @@ jobs:
     runs-on: ubuntu-latest
     timeout-minutes: 15
     steps:
-      - uses: actions/checkout@v4
-      - uses: actions/setup-python@v5
+      - uses: actions/checkout@v7
+      - uses: actions/setup-python@v7
         with:
           python-version: "3.14"
-      - uses: actions/setup-node@v4
+      - uses: actions/setup-node@v7
         with:
           node-version: "24.19.0"
           cache: npm
@@ -34,7 +34,7 @@ jobs:
           fi
       - name: Build Web UI once
         run: node scripts/prepare_rust_web_assets.mjs --install-deps
-      - uses: actions/upload-artifact@v4
+      - uses: actions/upload-artifact@v7
         with:
           name: release-rust-web-bundle
           path: web/dist
@@ -46,8 +46,8 @@ jobs:
     timeout-minutes: 45
     container: quay.io/pypa/manylinux_2_28_x86_64:latest
     steps:
-      - uses: actions/checkout@v4
-      - uses: actions/download-artifact@v4
+      - uses: actions/checkout@v7
+      - uses: actions/download-artifact@v8
         with:
           name: release-rust-web-bundle
           path: web/dist
@@ -75,7 +75,7 @@ jobs:
           cp target/release/cccc "dist/${package}/"
           cp LICENSE README.md docs/rust-migration.md "dist/${package}/"
           tar -C dist -czf "dist/${package}.tar.gz" "${package}"
-      - uses: actions/upload-artifact@v4
+      - uses: actions/upload-artifact@v7
         with:
           name: cccc-x86_64-unknown-linux-gnu
           path: dist/*.tar.gz
@@ -99,8 +99,8 @@ jobs:
     runs-on: ${{ matrix.os }}
     timeout-minutes: 45
     steps:
-      - uses: actions/checkout@v4
-      - uses: actions/download-artifact@v4
+      - uses: actions/checkout@v7
+      - uses: actions/download-artifact@v8
         with:
           name: release-rust-web-bundle
           path: web/dist
@@ -151,7 +151,7 @@ jobs:
           Copy-Item "target/${{ matrix.target }}/release/cccc.exe" "dist/$name/"
           Copy-Item LICENSE,README.md,docs/rust-migration.md "dist/$name/"
           Compress-Archive -Path "dist/$name" -DestinationPath "dist/$name.zip"
-      - uses: actions/upload-artifact@v4
+      - uses: actions/upload-artifact@v7
         with:
           name: cccc-${{ matrix.target }}
           path: dist/*.${{ matrix.archive }}
@@ -164,8 +164,8 @@ jobs:
     runs-on: ubuntu-latest
     timeout-minutes: 10
     steps:
-      - uses: actions/checkout@v4
-      - uses: actions/download-artifact@v4
+      - uses: actions/checkout@v7
+      - uses: actions/download-artifact@v8
         with:
           pattern: cccc-*
           path: artifacts
@@ -175,7 +175,7 @@ jobs:
         run: |
           version="$(sed -n 's/^version = "\([^"]*\)"/\1/p' Cargo.toml | head -1)"
           scripts/package_release_assets.sh artifacts "$version"
-      - uses: actions/upload-artifact@v4
+      - uses: actions/upload-artifact@v7
         with:
           name: cccc-release-candidate
           path: artifacts/*
@@ -202,8 +202,8 @@ jobs:
             verifier: windows
     runs-on: ${{ matrix.os }}
     steps:
-      - uses: actions/checkout@v4
-      - uses: actions/download-artifact@v4
+      - uses: actions/checkout@v7
+      - uses: actions/download-artifact@v8
         with:
           name: cccc-release-candidate
           path: artifacts
@@ -224,8 +224,8 @@ jobs:
     permissions:
       contents: write
     steps:
-      - uses: actions/checkout@v4
-      - uses: actions/download-artifact@v4
+      - uses: actions/checkout@v7
+      - uses: actions/download-artifact@v8
         with:
           name: cccc-release-candidate
           path: artifacts

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -19,15 +19,15 @@ jobs:
     timeout-minutes: 15
     steps:
       - name: Checkout
-        uses: actions/checkout@v4
+        uses: actions/checkout@v7
 
       - name: Set up Python
-        uses: actions/setup-python@v5
+        uses: actions/setup-python@v7
         with:
           python-version: "3.14"
 
       - name: Set up Node
-        uses: actions/setup-node@v4
+        uses: actions/setup-node@v7
         with:
           node-version: "24.19.0"
           cache: npm
@@ -63,7 +63,7 @@ jobs:
         run: python scripts/tests/smoke_wheel_frontdoor.py dist/*.whl --expect-rust unavailable
 
       - name: Upload shared Web bundle
-        uses: actions/upload-artifact@v4
+        uses: actions/upload-artifact@v7
         with:
           name: release-web-bundle
           path: |
@@ -72,7 +72,7 @@ jobs:
           if-no-files-found: error
 
       - name: Upload Python compatibility distribution
-        uses: actions/upload-artifact@v4
+        uses: actions/upload-artifact@v7
         with:
           name: release-dist-universal
           path: dist/*
@@ -85,10 +85,10 @@ jobs:
     container: quay.io/pypa/manylinux_2_28_x86_64:latest
     steps:
       - name: Checkout
-        uses: actions/checkout@v4
+        uses: actions/checkout@v7
 
       - name: Restore Web bundle
-        uses: actions/download-artifact@v4
+        uses: actions/download-artifact@v8
         with:
           name: release-web-bundle
           path: .
@@ -132,7 +132,7 @@ jobs:
         run: python scripts/tests/smoke_wheel_frontdoor.py wheelhouse/final/*.whl --expect-rust available
 
       - name: Upload Linux native wheel
-        uses: actions/upload-artifact@v4
+        uses: actions/upload-artifact@v7
         with:
           name: release-dist-linux-x64
           path: wheelhouse/final/*.whl
@@ -172,16 +172,16 @@ jobs:
         shell: bash
     steps:
       - name: Checkout
-        uses: actions/checkout@v4
+        uses: actions/checkout@v7
 
       - name: Restore Web bundle
-        uses: actions/download-artifact@v4
+        uses: actions/download-artifact@v8
         with:
           name: release-web-bundle
           path: .
 
       - name: Set up Python
-        uses: actions/setup-python@v5
+        uses: actions/setup-python@v7
         with:
           python-version: "3.14"
 
@@ -245,7 +245,7 @@ jobs:
         run: python scripts/tests/smoke_wheel_frontdoor.py wheelhouse/final/*.whl --expect-rust available
 
       - name: Upload native wheel
-        uses: actions/upload-artifact@v4
+        uses: actions/upload-artifact@v7
         with:
           name: release-dist-${{ matrix.artifact }}
           path: wheelhouse/final/*.whl
@@ -260,15 +260,15 @@ jobs:
     timeout-minutes: 5
     steps:
       - name: Checkout
-        uses: actions/checkout@v4
+        uses: actions/checkout@v7
 
       - name: Set up Python
-        uses: actions/setup-python@v5
+        uses: actions/setup-python@v7
         with:
           python-version: "3.14"
 
       - name: Download every release distribution
-        uses: actions/download-artifact@v4
+        uses: actions/download-artifact@v8
         with:
           pattern: release-dist-*
           path: dist
@@ -281,7 +281,7 @@ jobs:
           python scripts/verify_python_release_set.py dist
 
       - name: Upload verified release set
-        uses: actions/upload-artifact@v4
+        uses: actions/upload-artifact@v7
         with:
           name: release-dist
           path: dist/*
@@ -294,12 +294,12 @@ jobs:
     timeout-minutes: 10
     steps:
       - name: Set up Python
-        uses: actions/setup-python@v5
+        uses: actions/setup-python@v7
         with:
           python-version: "3.14"
 
       - name: Download verified release set
-        uses: actions/download-artifact@v4
+        uses: actions/download-artifact@v8
         with:
           name: release-dist
           path: dist

--- a/docs/guide/quality-gates.md
+++ b/docs/guide/quality-gates.md
@@ -69,6 +69,10 @@ the explicit override for testing a different bundle.
 
 CI pins Node 24.19.0 for reproducible formatting, linting, testing, and bundling, while `engines.node` defines the supported non-EOL local runtime range. The project deliberately does not use `devEngines`, because exact package-manager checks can prevent every `npm` and `npx` command from starting when a developer has a different compatible npm version.
 
+Workflow JavaScript actions use their Node 24-compatible major versions.
+Dependabot groups GitHub Actions updates into one weekly maintenance change so
+runner-runtime deprecations do not accumulate as warnings across every job.
+
 `npm run check` runs Vite+ Oxfmt and Oxlint, followed by the independent TypeScript 5.9 `tsc --noEmit` compatibility check. `npm run typecheck` remains available separately for focused diagnosis.
 
 Vite+ 0.2.4 / tsgolint 0.24 does not yet replace this project's `tsc` gate. Enabling both `lint.options.typeAware` and `typeCheck` produced 105 errors and 454 warnings across 439 files, while `tsc --noEmit` passed. Type-aware Vite+ checks remain disabled until their scope and diagnostics match the project; CI keeps the evidence-backed `vp check && npm run typecheck` combination.
@@ -86,18 +90,37 @@ Vite+ 0.2.4 / tsgolint 0.24 does not yet replace this project's `tsc` gate. Enab
 | `quality` | Ruff and quality-tool/workflow contract tests |
 | `web` | Vite+ Oxfmt/Oxlint check, independent TypeScript check, all Web tests, and the production bundle |
 | `python-tests` | Source-level Python tests distributed across four deterministic matrix shards |
+| `python-compat` | Import, CLI, and MCP handshake coverage on Python 3.11 through 3.13 |
 | `package` | Compile, build, Twine check, install, wheel resource smoke, and packaged Web bundle contract after quality/Web/Python pass |
-| `rust` | Python-free Rust workspace, installer/release assets, plus built CLI/daemon/MCP/code-mode replacement smoke on Ubuntu |
+| `rust-lint` | Rust formatting and workspace Clippy with warnings denied |
+| `rust-test` | Python-free Rust workspace plus installer/release source contracts |
+| `rust-process-lifecycle` | Serial combined daemon/Web lifecycle tests, isolated from the parallel workspace suite |
 | `interop` | Focused Python/Rust persisted-state and lock compatibility tests |
 | `windows-smoke` | Windows PTY compatibility tests |
+| `ci-required` | Stable aggregate result for branch protection; fails when any required job fails or is skipped |
 
-The Rust pull-request job is self-contained: it does not install or execute the
-Python backend. Cross-language tests that launch `src/cccc` stay excluded from
-that job so its boundary remains honest, but run in the separate mandatory
-`interop` job instead. All other Rust targets are still compiled, linted, and
-tested.
+The Rust pull-request jobs are self-contained: they do not install or execute
+the Python backend. Cross-language tests that launch `src/cccc` stay excluded
+from `rust-test` so its boundary remains honest, but run in the separate
+mandatory `interop` job instead. CLI tests that spawn and stop a combined
+daemon/Web process are also excluded from the parallel workspace invocation and
+run with one test thread in `rust-process-lifecycle`. This preserves the process
+exit contract without making it race the rest of the workspace test binary.
 
-The Rust job also executes `scripts/tests/smoke_rust_replacement.sh` against the
+## Post-Merge Native Verification
+
+Slow native distribution checks live in the separate `Post-merge` workflow so
+pull requests do not contain push-only skipped jobs and the required CI result
+stays easy to read. It runs only after changes land on `main` or `rust`:
+
+| Job | Responsibility |
+| --- | --- |
+| `web-bundle` | Build the exact frontend embedded by native artifacts |
+| `rust-dist` | Release-build the Rust workspace and run Unix installation/replacement smoke |
+| `windows-installer` | Build the native Windows CLI and verify installer ownership and PATH handling |
+| `post-merge-required` | Stable aggregate result for the slow native verification layer |
+
+`rust-dist` executes `scripts/tests/smoke_rust_replacement.sh` against the
 actual built executable. The smoke uses a fresh `CCCC_HOME`, verifies offline
 `status`, starts the daemon, creates a scoped Web Model actor, performs an MCP
 handshake and a real `cccc_code_exec` cell, then stops the daemon and verifies

--- a/tests/test_quality_ci_workflow.py
+++ b/tests/test_quality_ci_workflow.py
@@ -34,6 +34,13 @@ def _nightly_workflow() -> dict:
     )
 
 
+def _post_merge_workflow() -> dict:
+    return yaml.load(
+        (ROOT / ".github/workflows/post-merge.yml").read_text(encoding="utf-8"),
+        Loader=yaml.BaseLoader,
+    )
+
+
 def _runs(job: dict) -> str:
     return "\n".join(step.get("run", "") for step in job.get("steps", []))
 
@@ -44,7 +51,7 @@ def test_ci_has_read_only_permissions_bounded_jobs_and_cancels_stale_runs() -> N
 
     assert workflow["permissions"] == {"contents": "read"}
     assert workflow["concurrency"] == {
-        "group": "ci-${{ github.workflow }}-${{ github.ref }}",
+        "group": "ci-${{ github.event.pull_request.number || github.ref }}",
         "cancel-in-progress": "true",
     }
     assert {name: job.get("timeout-minutes") for name, job in jobs.items()} == {
@@ -54,13 +61,13 @@ def test_ci_has_read_only_permissions_bounded_jobs_and_cancels_stale_runs() -> N
         "python-compat": "15",
         "package": "25",
         "windows-smoke": "20",
-        "windows-installer": "40",
         "rust-lint": "15",
         "rust-test": "45",
-        "rust-dist": "30",
+        "rust-process-lifecycle": "15",
         "interop": "30",
+        "ci-required": "5",
     }
-    for name in ("rust-lint", "rust-test", "rust-dist"):
+    for name in ("rust-lint", "rust-test", "rust-process-lifecycle"):
         rust_toolchain = next(
             step["uses"]
             for step in jobs[name]["steps"]
@@ -82,11 +89,24 @@ def test_pr_jobs_keep_full_quality_web_python_and_package_boundaries() -> None:
         "interop",
         "rust-lint",
         "rust-test",
+        "rust-process-lifecycle",
+        "ci-required",
     } <= set(jobs)
-    # Release-asset verification is deliberately post-merge: native builds
-    # are too slow for the PR critical path and run when changes land.
-    for gated in ("rust-dist", "windows-installer"):
-        assert jobs[gated]["if"] == "github.event_name == 'push'", gated
+    assert "rust-dist" not in jobs
+    assert "windows-installer" not in jobs
+    assert set(jobs["ci-required"]["needs"]) == {
+        "quality",
+        "web",
+        "python-tests",
+        "python-compat",
+        "package",
+        "windows-smoke",
+        "rust-lint",
+        "rust-test",
+        "rust-process-lifecycle",
+        "interop",
+    }
+    assert jobs["ci-required"]["if"] == "always()"
     assert set(jobs["package"]["needs"]) == {"quality", "web", "python-tests", "python-compat", "interop"}
     assert "ruff check" in _runs(jobs["quality"])
     assert "npm -C web test" in _runs(jobs["web"])
@@ -124,13 +144,12 @@ def test_windows_smoke_keeps_the_product_pty_checks_without_web_migration_setup(
     assert "npm " not in runs
 
 
-def test_windows_installer_job_is_a_push_gated_native_fixture() -> None:
-    installer = _workflow()["jobs"]["windows-installer"]
+def test_windows_installer_job_is_a_post_merge_native_fixture() -> None:
+    installer = _post_merge_workflow()["jobs"]["windows-installer"]
     runs = _runs(installer)
     uses = {step.get("uses", "") for step in installer["steps"]}
 
-    assert installer["if"] == "github.event_name == 'push'"
-    assert installer["needs"] == "web"
+    assert installer["needs"] == "web-bundle"
     assert "cargo build --release --locked -p cccc --bin cccc" in runs
     assert "scripts/tests/install_windows.ps1" in runs
     assert any(item.startswith("actions/download-artifact") for item in uses)
@@ -140,7 +159,7 @@ def test_windows_installer_job_is_a_push_gated_native_fixture() -> None:
 def test_rust_jobs_are_python_free_and_serialize_daemon_tests() -> None:
     jobs = _workflow()["jobs"]
 
-    for name in ("rust-lint", "rust-test", "rust-dist"):
+    for name in ("rust-lint", "rust-test", "rust-process-lifecycle"):
         job = jobs[name]
         runs = _runs(job)
         uses = {step.get("uses", "") for step in job["steps"]}
@@ -157,6 +176,11 @@ def test_rust_jobs_are_python_free_and_serialize_daemon_tests() -> None:
         in test_runs
     )
     assert test_runs.count("--skip python_interop_") == 2
+    assert "--skip daemon_self_launch::" in test_runs
+    lifecycle_runs = _runs(jobs["rust-process-lifecycle"])
+    assert "--test integration" in lifecycle_runs
+    assert "daemon_self_launch::" in lifecycle_runs
+    assert "--test-threads=1" in lifecycle_runs
     assert "cargo fmt --all --check" in _runs(jobs["rust-lint"])
     assert "cargo clippy --workspace --all-targets -- -D warnings" in _runs(jobs["rust-lint"])
 
@@ -190,13 +214,13 @@ def test_python_backed_rust_tests_share_one_explicit_ci_category() -> None:
 
 
 def test_rust_dist_and_manual_verifiers_cover_replacement_smoke() -> None:
-    dist = _workflow()["jobs"]["rust-dist"]
+    dist = _post_merge_workflow()["jobs"]["rust-dist"]
     runs = _runs(dist)
     unix_verifier = (ROOT / "scripts/tests/verify_release_unix.sh").read_text(encoding="utf-8")
     windows_verifier = (ROOT / "scripts/tests/verify_release_windows.ps1").read_text(encoding="utf-8")
     windows_installer = (ROOT / "scripts/install.ps1").read_text(encoding="utf-8")
 
-    assert dist["if"] == "github.event_name == 'push'"
+    assert dist["needs"] == "web-bundle"
     assert "cargo build --workspace --release --locked" in runs
     assert "scripts/tests/smoke_rust_replacement.sh target/release/cccc" in runs
     assert "smoke_rust_replacement.sh" in unix_verifier
@@ -301,6 +325,66 @@ def test_nightly_workflow_runs_serial_full_python_suite_at_the_oldest_endpoint()
     assert "pytest_shards.py" not in runs
     assert "pytest-xdist" not in runs
     assert " -n " not in runs
+
+
+def test_post_merge_workflow_owns_slow_native_verification() -> None:
+    workflow = _post_merge_workflow()
+    jobs = workflow["jobs"]
+
+    assert set(workflow["on"]) == {"push", "workflow_dispatch"}
+    assert workflow["on"]["push"]["branches"] == ["main", "rust"]
+    assert workflow["permissions"] == {"contents": "read"}
+    assert workflow["concurrency"] == {
+        "group": "post-merge-${{ github.ref }}",
+        "cancel-in-progress": "true",
+    }
+    assert set(jobs) == {
+        "web-bundle",
+        "rust-dist",
+        "windows-installer",
+        "post-merge-required",
+    }
+    assert jobs["post-merge-required"]["if"] == "always()"
+    assert set(jobs["post-merge-required"]["needs"]) == {
+        "web-bundle",
+        "rust-dist",
+        "windows-installer",
+    }
+
+
+def test_workflows_use_node24_actions_and_schedule_action_updates() -> None:
+    workflow_sources = "\n".join(
+        path.read_text(encoding="utf-8")
+        for path in sorted((ROOT / ".github/workflows").glob("*.yml"))
+    )
+
+    for legacy in (
+        "actions/checkout@v4",
+        "actions/setup-python@v5",
+        "actions/setup-node@v4",
+        "actions/upload-artifact@v4",
+        "actions/download-artifact@v4",
+    ):
+        assert legacy not in workflow_sources
+    for current in (
+        "actions/checkout@v7",
+        "actions/setup-python@v7",
+        "actions/setup-node@v7",
+        "actions/upload-artifact@v7",
+        "actions/download-artifact@v8",
+    ):
+        assert current in workflow_sources
+
+    dependabot = yaml.safe_load(
+        (ROOT / ".github/dependabot.yml").read_text(encoding="utf-8")
+    )
+    action_updates = next(
+        update
+        for update in dependabot["updates"]
+        if update["package-ecosystem"] == "github-actions"
+    )
+    assert action_updates["directory"] == "/"
+    assert action_updates["schedule"]["interval"] == "weekly"
 
 
 def test_python_release_builds_one_atomic_dual_implementation_set() -> None:


### PR DESCRIPTION
## Summary

- isolate daemon/process lifecycle integration tests in a dedicated serial CI job to remove load-sensitive stop races
- keep pull-request CI focused on core cross-platform quality gates and move native release/installer smoke tests to a post-merge workflow
- add stable required-check aggregators for PR and post-merge workflows
- upgrade official GitHub Actions to Node 24-based majors and add weekly Dependabot maintenance
- synchronize CI contract tests and quality-gate documentation

## Root cause

The failing `daemon_stop_waits_for_the_combined_web_process_to_exit` test shared a runner with the parallel Rust workspace suite. Under CI load, daemon shutdown could exceed the fixed 15-second lease wait even though the same commit passed on main and repeated local runs. The lifecycle suite now runs separately with `--test-threads=1`.

## Local verification

- `actionlint` v1.7.12 (published checksum verified)
- `cargo fmt --all --check`
- `cargo clippy --workspace --all-targets -- -D warnings`
- workflow-equivalent Rust workspace, daemon, and lifecycle test commands
- 42 CI/configuration contract tests
- Ruff and whitespace checks
- `graphify update .`
