### PR TITLE
release: prepare v0.4.34-rc4

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -9,3 +9,8 @@ updates:
       github-actions:
         patterns:
           - "*"
+    # This action intentionally encodes the Rust toolchain in its ref
+    # (for example @1.88.0). Dependabot mistakes that for an action release and
+    # proposes nonexistent Rust versions such as 1.100.0.
+    ignore:
+      - dependency-name: dtolnay/rust-toolchain

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,10 +6,19 @@ The format follows [Keep a Changelog](https://keepachangelog.com/), and versions
 
 ## [Unreleased]
 
+## [0.4.34-rc4] — 2026-08-15
+
+### Changed
+- **CI now isolates process-lifecycle coverage and post-merge native verification.** The load-sensitive daemon/Web shutdown suite runs serially outside the parallel Rust workspace tests, while native distribution and Windows installer checks run after merge behind stable aggregate gates.
+- **GitHub Actions updates no longer rewrite the pinned Rust compiler version.** Dependabot continues maintaining normal Actions dependencies but ignores `dtolnay/rust-toolchain`, whose action ref intentionally encodes the workspace's Rust 1.88 toolchain.
+
 ### Fixed
 - **Voice Secretary recordings keep their original Group scope while navigating.** Switching Groups during an active recording no longer redirects document checkpoints, final transcripts, Ask/Prompt work, or direct-composer text into the newly visible Group; the immutable recording scope continues targeting the original Group and document, with composer text routed to that Group's preserved draft.
 - **Silent Voice Secretary streams no longer grow the native ASR heap without bound.** Rust now resets sherpa-onnx at every detected endpoint even when the hypothesis is empty or unchanged, releasing accumulated streaming features while preserving final transcript events.
 - **Long Voice Secretary recordings no longer block later stops or permanently lose speaker labels.** Short WebSocket recordings still receive immediate final ASR; when speaker analysis is available, persistent recordings over 30 seconds, or recordings stopped while native inference is occupied, complete stop promptly and retain their durable live transcript while speaker analysis waits behind the active job instead of returning `worker_busy`. Final ASR paths that cannot defer reuse one SenseVoice recognizer across bounded 30-second ranges.
+- **Message delivery preferences and lifecycle state stay aligned across runtime paths.** Delivery recovery no longer drifts from the actor's persisted mode or leaves stale lifecycle projections behind.
+- **The embedded CLI reacts to daemon loss without polling.** Combined process shutdown follows the daemon exit signal directly, reducing delayed or inconsistent teardown behavior.
+- **Capability discovery exposes autoload candidates consistently.** The daemon includes the candidate state expected by clients, and the Web capability picker now has complete English, Chinese, and Japanese labels.
 
 ## [0.4.34-rc3] — 2026-08-14
 

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -427,7 +427,7 @@ dependencies = [
 
 [[package]]
 name = "cccc"
-version = "0.4.34-rc3"
+version = "0.4.34-rc4"
 dependencies = [
  "anyhow",
  "cccc-pair-client",
@@ -449,7 +449,7 @@ dependencies = [
 
 [[package]]
 name = "cccc-pair-client"
-version = "0.4.34-rc3"
+version = "0.4.34-rc4"
 dependencies = [
  "cccc-pair-contracts",
  "cccc-pair-core",
@@ -460,7 +460,7 @@ dependencies = [
 
 [[package]]
 name = "cccc-pair-contracts"
-version = "0.4.34-rc3"
+version = "0.4.34-rc4"
 dependencies = [
  "chrono",
  "serde",
@@ -470,7 +470,7 @@ dependencies = [
 
 [[package]]
 name = "cccc-pair-core"
-version = "0.4.34-rc3"
+version = "0.4.34-rc4"
 dependencies = [
  "aws-lc-rs",
  "base64",
@@ -496,7 +496,7 @@ dependencies = [
 
 [[package]]
 name = "cccc-pair-daemon"
-version = "0.4.34-rc3"
+version = "0.4.34-rc4"
 dependencies = [
  "anyhow",
  "base64",
@@ -530,7 +530,7 @@ dependencies = [
 
 [[package]]
 name = "cccc-pair-mcp"
-version = "0.4.34-rc3"
+version = "0.4.34-rc4"
 dependencies = [
  "anyhow",
  "axum",
@@ -555,7 +555,7 @@ dependencies = [
 
 [[package]]
 name = "cccc-pair-notebooklm"
-version = "0.4.34-rc3"
+version = "0.4.34-rc4"
 dependencies = [
  "cookie",
  "regex",
@@ -567,7 +567,7 @@ dependencies = [
 
 [[package]]
 name = "cccc-pair-runtime"
-version = "0.4.34-rc3"
+version = "0.4.34-rc4"
 dependencies = [
  "cccc-pair-contracts",
  "portable-pty",
@@ -600,7 +600,7 @@ dependencies = [
 
 [[package]]
 name = "cccc-pair-web"
-version = "0.4.34-rc3"
+version = "0.4.34-rc4"
 dependencies = [
  "aes",
  "anyhow",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -18,7 +18,7 @@ exclude = [
 ]
 
 [workspace.package]
-version = "0.4.34-rc3"
+version = "0.4.34-rc4"
 edition = "2024"
 license = "Apache-2.0"
 repository = "https://github.com/ChesterRa/cccc"

--- a/README.ja.md
+++ b/README.ja.md
@@ -520,7 +520,7 @@ powershell.exe -NoProfile -ExecutionPolicy Bypass -Command "[Net.ServicePointMan
 新しいターミナルで `cccc doctor` を実行すると、`Installation` セクションに
 実行中の入口、PATH が選ぶコマンド、競合するすべてのパスが表示されます。
 
-現在のネイティブインストーラーは `v0.4.34-rc3` リリース候補を固定してインストールします。
+現在のネイティブインストーラーは `v0.4.34-rc4` リリース候補を固定してインストールします。
 
 ### pip（RC 版、TestPyPI）
 

--- a/README.md
+++ b/README.md
@@ -530,7 +530,7 @@ any remaining duplicates. Open a new terminal and run `cccc doctor`; its
 `Installation` section reports the invoked executable, the command selected by
 PATH, and every conflicting command.
 
-The hosted native installer currently pins the `v0.4.34-rc3` release candidate.
+The hosted native installer currently pins the `v0.4.34-rc4` release candidate.
 
 ### pip (RC from TestPyPI)
 

--- a/README.zh-CN.md
+++ b/README.zh-CN.md
@@ -515,7 +515,7 @@ powershell.exe -NoProfile -ExecutionPolicy Bypass -Command "[Net.ServicePointMan
 PATH 最前面，并列出仍然存在的重复命令。打开新终端后运行 `cccc doctor`，其
 `Installation` 部分会显示本次入口、PATH 实际命中的命令以及全部冲突路径。
 
-当前托管的原生安装器固定安装 `v0.4.34-rc3` 候选版本。
+当前托管的原生安装器固定安装 `v0.4.34-rc4` 候选版本。
 
 ### pip（RC 版，TestPyPI）
 

--- a/crates/cccc-cli/Cargo.toml
+++ b/crates/cccc-cli/Cargo.toml
@@ -20,13 +20,13 @@ standalone = ["dep:openssl-sys"]
 
 [dependencies]
 anyhow.workspace = true
-cccc-client = { package = "cccc-pair-client", version = "=0.4.34-rc3", path = "../cccc-client" }
-cccc-contracts = { package = "cccc-pair-contracts", version = "=0.4.34-rc3", path = "../cccc-contracts" }
-cccc-core = { package = "cccc-pair-core", version = "=0.4.34-rc3", path = "../cccc-core" }
-cccc-daemon = { package = "cccc-pair-daemon", version = "=0.4.34-rc3", path = "../cccc-daemon" }
-cccc-mcp = { package = "cccc-pair-mcp", version = "=0.4.34-rc3", path = "../cccc-mcp" }
-cccc-runtime = { package = "cccc-pair-runtime", version = "=0.4.34-rc3", path = "../cccc-runtime" }
-cccc-web = { package = "cccc-pair-web", version = "=0.4.34-rc3", path = "../cccc-web" }
+cccc-client = { package = "cccc-pair-client", version = "=0.4.34-rc4", path = "../cccc-client" }
+cccc-contracts = { package = "cccc-pair-contracts", version = "=0.4.34-rc4", path = "../cccc-contracts" }
+cccc-core = { package = "cccc-pair-core", version = "=0.4.34-rc4", path = "../cccc-core" }
+cccc-daemon = { package = "cccc-pair-daemon", version = "=0.4.34-rc4", path = "../cccc-daemon" }
+cccc-mcp = { package = "cccc-pair-mcp", version = "=0.4.34-rc4", path = "../cccc-mcp" }
+cccc-runtime = { package = "cccc-pair-runtime", version = "=0.4.34-rc4", path = "../cccc-runtime" }
+cccc-web = { package = "cccc-pair-web", version = "=0.4.34-rc4", path = "../cccc-web" }
 clap.workspace = true
 fs2.workspace = true
 reqwest.workspace = true

--- a/crates/cccc-client/Cargo.toml
+++ b/crates/cccc-client/Cargo.toml
@@ -9,8 +9,8 @@ description = "IPC client for the CCCC collaborative agent control plane"
 publish = false
 
 [dependencies]
-cccc-contracts = { package = "cccc-pair-contracts", version = "=0.4.34-rc3", path = "../cccc-contracts" }
-cccc-core = { package = "cccc-pair-core", version = "=0.4.34-rc3", path = "../cccc-core" }
+cccc-contracts = { package = "cccc-pair-contracts", version = "=0.4.34-rc4", path = "../cccc-contracts" }
+cccc-core = { package = "cccc-pair-core", version = "=0.4.34-rc4", path = "../cccc-core" }
 serde_json.workspace = true
 thiserror.workspace = true
 tokio.workspace = true

--- a/crates/cccc-core/Cargo.toml
+++ b/crates/cccc-core/Cargo.toml
@@ -11,7 +11,7 @@ publish = false
 [dependencies]
 aws-lc-rs.workspace = true
 base64.workspace = true
-cccc-contracts = { package = "cccc-pair-contracts", version = "=0.4.34-rc3", path = "../cccc-contracts" }
+cccc-contracts = { package = "cccc-pair-contracts", version = "=0.4.34-rc4", path = "../cccc-contracts" }
 chrono.workspace = true
 chrono-tz.workspace = true
 cron.workspace = true

--- a/crates/cccc-daemon/Cargo.toml
+++ b/crates/cccc-daemon/Cargo.toml
@@ -11,11 +11,11 @@ publish = false
 [dependencies]
 anyhow.workspace = true
 base64.workspace = true
-cccc-client = { package = "cccc-pair-client", version = "=0.4.34-rc3", path = "../cccc-client" }
-cccc-contracts = { package = "cccc-pair-contracts", version = "=0.4.34-rc3", path = "../cccc-contracts" }
-cccc-core = { package = "cccc-pair-core", version = "=0.4.34-rc3", path = "../cccc-core" }
-cccc-notebooklm = { package = "cccc-pair-notebooklm", version = "=0.4.34-rc3", path = "../cccc-notebooklm" }
-cccc-runtime = { package = "cccc-pair-runtime", version = "=0.4.34-rc3", path = "../cccc-runtime" }
+cccc-client = { package = "cccc-pair-client", version = "=0.4.34-rc4", path = "../cccc-client" }
+cccc-contracts = { package = "cccc-pair-contracts", version = "=0.4.34-rc4", path = "../cccc-contracts" }
+cccc-core = { package = "cccc-pair-core", version = "=0.4.34-rc4", path = "../cccc-core" }
+cccc-notebooklm = { package = "cccc-pair-notebooklm", version = "=0.4.34-rc4", path = "../cccc-notebooklm" }
+cccc-runtime = { package = "cccc-pair-runtime", version = "=0.4.34-rc4", path = "../cccc-runtime" }
 chrono.workspace = true
 clap.workspace = true
 fs2.workspace = true

--- a/crates/cccc-mcp/Cargo.toml
+++ b/crates/cccc-mcp/Cargo.toml
@@ -11,10 +11,10 @@ publish = false
 [dependencies]
 anyhow.workspace = true
 base64.workspace = true
-cccc-client = { package = "cccc-pair-client", version = "=0.4.34-rc3", path = "../cccc-client" }
-cccc-contracts = { package = "cccc-pair-contracts", version = "=0.4.34-rc3", path = "../cccc-contracts" }
-cccc-core = { package = "cccc-pair-core", version = "=0.4.34-rc3", path = "../cccc-core" }
-cccc-runtime = { package = "cccc-pair-runtime", version = "=0.4.34-rc3", path = "../cccc-runtime" }
+cccc-client = { package = "cccc-pair-client", version = "=0.4.34-rc4", path = "../cccc-client" }
+cccc-contracts = { package = "cccc-pair-contracts", version = "=0.4.34-rc4", path = "../cccc-contracts" }
+cccc-core = { package = "cccc-pair-core", version = "=0.4.34-rc4", path = "../cccc-core" }
+cccc-runtime = { package = "cccc-pair-runtime", version = "=0.4.34-rc4", path = "../cccc-runtime" }
 chrono.workspace = true
 regex.workspace = true
 reqwest.workspace = true
@@ -28,7 +28,7 @@ uuid.workspace = true
 
 [dev-dependencies]
 axum.workspace = true
-cccc-daemon = { package = "cccc-pair-daemon", version = "=0.4.34-rc3", path = "../cccc-daemon" }
+cccc-daemon = { package = "cccc-pair-daemon", version = "=0.4.34-rc4", path = "../cccc-daemon" }
 tempfile.workspace = true
 
 [lints]

--- a/crates/cccc-runtime/Cargo.toml
+++ b/crates/cccc-runtime/Cargo.toml
@@ -9,7 +9,7 @@ description = "Process and terminal runtime management for CCCC"
 publish = false
 
 [dependencies]
-cccc-contracts = { package = "cccc-pair-contracts", version = "=0.4.34-rc3", path = "../cccc-contracts" }
+cccc-contracts = { package = "cccc-pair-contracts", version = "=0.4.34-rc4", path = "../cccc-contracts" }
 portable-pty.workspace = true
 retach.workspace = true
 serde.workspace = true

--- a/crates/cccc-web/Cargo.toml
+++ b/crates/cccc-web/Cargo.toml
@@ -22,11 +22,11 @@ async-trait.workspace = true
 axum.workspace = true
 base64.workspace = true
 bzip2.workspace = true
-cccc-client = { package = "cccc-pair-client", version = "=0.4.34-rc3", path = "../cccc-client" }
-cccc-contracts = { package = "cccc-pair-contracts", version = "=0.4.34-rc3", path = "../cccc-contracts" }
-cccc-core = { package = "cccc-pair-core", version = "=0.4.34-rc3", path = "../cccc-core" }
-cccc-mcp = { package = "cccc-pair-mcp", version = "=0.4.34-rc3", path = "../cccc-mcp" }
-cccc-runtime = { package = "cccc-pair-runtime", version = "=0.4.34-rc3", path = "../cccc-runtime" }
+cccc-client = { package = "cccc-pair-client", version = "=0.4.34-rc4", path = "../cccc-client" }
+cccc-contracts = { package = "cccc-pair-contracts", version = "=0.4.34-rc4", path = "../cccc-contracts" }
+cccc-core = { package = "cccc-pair-core", version = "=0.4.34-rc4", path = "../cccc-core" }
+cccc-mcp = { package = "cccc-pair-mcp", version = "=0.4.34-rc4", path = "../cccc-mcp" }
+cccc-runtime = { package = "cccc-pair-runtime", version = "=0.4.34-rc4", path = "../cccc-runtime" }
 chromiumoxide.workspace = true
 chrono.workspace = true
 crc32fast.workspace = true
@@ -65,7 +65,7 @@ url.workspace = true
 weixin-agent.workspace = true
 
 [dev-dependencies]
-cccc-daemon = { package = "cccc-pair-daemon", version = "=0.4.34-rc3", path = "../cccc-daemon" }
+cccc-daemon = { package = "cccc-pair-daemon", version = "=0.4.34-rc4", path = "../cccc-daemon" }
 http-body-util.workspace = true
 tower.workspace = true
 

--- a/docs/guide/getting-started/index.md
+++ b/docs/guide/getting-started/index.md
@@ -134,7 +134,7 @@ powershell.exe -NoProfile -ExecutionPolicy Bypass -Command "[Net.ServicePointMan
 The installer downloads a checksum-verified GitHub Release binary. It does not
 require a Rust or Python toolchain and refuses to overwrite an existing `cccc`
 command it does not own. Uninstall that command deliberately or choose another
-`CCCC_INSTALL_DIR` first. During the `v0.4.34-rc3` validation period, the hosted
+`CCCC_INSTALL_DIR` first. During the `v0.4.34-rc4` validation period, the hosted
 installer is pinned to that release candidate. You can also select it explicitly
 with `CCCC_VERSION`:
 
@@ -144,11 +144,11 @@ a new terminal after installation and run `cccc doctor` to verify that PATH
 resolves to the executable you just installed.
 
 ```bash
-curl -fsSL https://chesterra.github.io/cccc/install.sh | CCCC_VERSION=0.4.34-rc3 sh
+curl -fsSL https://chesterra.github.io/cccc/install.sh | CCCC_VERSION=0.4.34-rc4 sh
 ```
 
 ```powershell
-$env:CCCC_VERSION = "0.4.34-rc3"
+$env:CCCC_VERSION = "0.4.34-rc4"
 powershell.exe -NoProfile -ExecutionPolicy Bypass -Command "[Net.ServicePointManager]::SecurityProtocol = [Net.ServicePointManager]::SecurityProtocol -bor [Net.SecurityProtocolType]::Tls12; Invoke-RestMethod 'https://chesterra.github.io/cccc/install.ps1' | Invoke-Expression"
 Remove-Item Env:CCCC_VERSION
 ```

--- a/docs/package-lock.json
+++ b/docs/package-lock.json
@@ -2065,9 +2065,9 @@
       "license": "MIT"
     },
     "node_modules/nanoid": {
-      "version": "3.3.15",
-      "resolved": "https://registry.npmjs.org/nanoid/-/nanoid-3.3.15.tgz",
-      "integrity": "sha512-y7Wygv/7mEOvxTuEQDB8StXdMRBWf1kR/tlhAzBRUFkB2jfcLOAxO/SHmOO2zgz1pVgK29/kyupn059/bCHdjA==",
+      "version": "3.3.18",
+      "resolved": "https://registry.npmjs.org/nanoid/-/nanoid-3.3.18.tgz",
+      "integrity": "sha512-DTg4MJbGMWkfi6VZFdNt2/caMbQy4Ou+Op/hJQvGEWcnVfoA1QA+xzRKAzw9jD6+GVOOeYr/mIcuDSdug6F6+w==",
       "dev": true,
       "funding": [
         {
@@ -2123,9 +2123,9 @@
       }
     },
     "node_modules/postcss": {
-      "version": "8.5.16",
-      "resolved": "https://registry.npmjs.org/postcss/-/postcss-8.5.16.tgz",
-      "integrity": "sha512-vuwillviilfKZsg0VGj5R/YwwcHx4SLsIOI/7K6mQkWx+l5cUHTjj5g0AasTBcyXsbfTgrwsUNmVUb5xVwyPwg==",
+      "version": "8.5.26",
+      "resolved": "https://registry.npmjs.org/postcss/-/postcss-8.5.26.tgz",
+      "integrity": "sha512-u82N74LFzG8ca+dD8puPnplTXoGH4fTPpVGuIbt36G3qvNlkvfD0lEAZSxaly3KX8TS/L1A1gsCEmvKmBcVbkQ==",
       "dev": true,
       "funding": [
         {
@@ -2143,7 +2143,7 @@
       ],
       "license": "MIT",
       "dependencies": {
-        "nanoid": "^3.3.12",
+        "nanoid": "^3.3.17",
         "picocolors": "^1.1.1",
         "source-map-js": "^1.2.1"
       },

--- a/docs/release/v0.4.34_release_notes.md
+++ b/docs/release/v0.4.34_release_notes.md
@@ -1,18 +1,38 @@
-# CCCC v0.4.34-rc3 Release Notes
+# CCCC v0.4.34-rc4 Release Notes
 
 This release candidate validates the complete pip distribution with its bundled
 Rust implementation, plus an optional experimental standalone Rust preview,
 before the stable `v0.4.34` release.
 
-`v0.4.34-rc3` brings the native Rust implementation onto the same product and release
+`v0.4.34-rc4` brings the native Rust implementation onto the same product and release
 line as CCCC's Python distribution, adds Cline as a first-class runtime, and
 tightens the authorization and release boundaries that matter when CCCC is used
 across multiple Working Groups.
 
+## RC4 Stabilization Since RC3
+
+RC4 concentrates the changes made after RC3 into one release-tested candidate.
+Voice Secretary now keeps the Group and document captured at recording start even
+when the operator navigates elsewhere, bounds native ASR memory at silent
+endpoints, and lets long recordings finish promptly while speaker analysis waits
+for the active inference lease. Final ASR timeout invariants remain runtime-checked
+under Clippy's warnings-as-errors policy.
+
+Delivery preferences and actor lifecycle projections now stay aligned across
+recovery paths. The combined CLI follows embedded-daemon loss through an
+event-driven signal, capability discovery emits the autoload candidate expected
+by clients, and the Web capability picker includes its complete localized labels.
+
+The release gates themselves are less sensitive to runner contention. Combined
+daemon/Web lifecycle tests run in an isolated serial job, native distribution and
+Windows installer checks run after merge, and stable aggregate checks summarize
+both stages. Dependabot continues updating normal GitHub Actions while leaving
+the intentionally pinned Rust 1.88 toolchain ref under manual version control.
+
 ## One CCCC Installation, Two Implementations
 
-Python uses PEP 440 `0.4.34rc3`, Rust uses SemVer `0.4.34-rc3`, and both map to
-the canonical `v0.4.34-rc3` tag. The release candidate is published to TestPyPI.
+Python uses PEP 440 `0.4.34rc4`, Rust uses SemVer `0.4.34-rc4`, and both map to
+the canonical `v0.4.34-rc4` tag. The release candidate is published to TestPyPI.
 The stable and recommended `cccc-pair` distribution keeps Python as its initial
 default and bundles a private Rust executable in supported platform wheels.
 Other pip platforms retain the universal Python fallback. Linux x86-64, Intel
@@ -136,7 +156,7 @@ instead of being misclassified as optional capability tool calls.
 - Existing custom Cline actor commands remain valid. New actors use CCCC's formal
   Cline defaults, and `cccc setup --runtime cline` can repair the MCP entry.
 - Manual release dispatches perform build and verification only. A pushed
-  `v0.4.34-rc3` tag publishes the Python artifacts to TestPyPI; the experimental
+  `v0.4.34-rc4` tag publishes the Python artifacts to TestPyPI; the experimental
   standalone archives, checksums, and installers are published only when an
   operator separately runs their workflow on that matching tag.
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "setuptools.build_meta"
 
 [project]
 name = "cccc-pair"
-version = "0.4.34rc3"
+version = "0.4.34rc4"
 description = "Global multi-agent delivery kernel with working groups, scopes, and an append-only collaboration ledger"
 readme = { file = "README.md", content-type = "text/markdown" }
 requires-python = ">=3.11"

--- a/tests/test_quality_ci_workflow.py
+++ b/tests/test_quality_ci_workflow.py
@@ -385,6 +385,9 @@ def test_workflows_use_node24_actions_and_schedule_action_updates() -> None:
     )
     assert action_updates["directory"] == "/"
     assert action_updates["schedule"]["interval"] == "weekly"
+    assert {
+        dependency["dependency-name"] for dependency in action_updates["ignore"]
+    } == {"dtolnay/rust-toolchain"}
 
 
 def test_python_release_builds_one_atomic_dual_implementation_set() -> None:

--- a/tests/test_verify_python_release_set.py
+++ b/tests/test_verify_python_release_set.py
@@ -7,7 +7,7 @@ import pytest
 from scripts.verify_python_release_set import MAX_WHEEL_BYTES, WHEEL_SUFFIXES, verify
 
 
-PREFIX = "cccc_pair-0.4.34rc3"
+PREFIX = "cccc_pair-0.4.34rc4"
 
 
 def _complete_set(directory: Path) -> None:


### PR DESCRIPTION
## 概要

- 修复 Dependabot 将 `dtolnay/rust-toolchain@1.88.0` 误判为可升级 Action 版本并生成不存在的 Rust `1.100.0` 的问题
- 增加 CI 配置契约测试，锁定该手工管理的 toolchain 依赖
- 将 Rust/Python/文档版本统一推进到 `v0.4.34-rc4`
- 同步 changelog、RC 发布说明与安装文档
- 更新文档站点锁文件中的安全补丁依赖，`npm audit` 为 0

## 本地验证

- Rust：`cargo fmt --all --check`
- Rust：`cargo clippy --workspace --all-targets --locked -- -D warnings`
- Rust：完整工作区测试与文档测试
- Python：版本一致性、CI 契约、发布集合测试（49 项）
- Python：sdist/wheel 构建、Twine 检查、wheel 生命周期 smoke
- Docs：`npm ci`、VitePress build、`npm audit`
- Release：版本一致性与 release assets 检查

本 PR 仅完成 RC4 发布准备，不创建或推送 release tag。