### PR TITLE
chore(release): merge v0.4.35-rc1 into main

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -235,7 +235,7 @@ jobs:
   windows-smoke:
     needs: web
     runs-on: windows-latest
-    timeout-minutes: 20
+    timeout-minutes: 30
     steps:
       - name: Checkout
         uses: actions/checkout@v7
@@ -267,6 +267,13 @@ jobs:
         uses: dtolnay/rust-toolchain@1.88.0
 
       - uses: Swatinem/rust-cache@v2
+
+      - name: Verify combined Web startup failure releases its daemon
+        timeout-minutes: 10
+        run: >-
+          cargo test --package cccc --test integration --locked
+          daemon_self_launch::combined_web_bind_failure_stops_its_owned_daemon
+          -- --test-threads=1
 
       - name: Verify abrupt daemon process-tree cleanup
         timeout-minutes: 10

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -293,6 +293,9 @@ jobs:
     runs-on: ubuntu-latest
     timeout-minutes: 10
     steps:
+      - name: Checkout
+        uses: actions/checkout@v7
+
       - name: Set up Python
         uses: actions/setup-python@v7
         with:
@@ -322,11 +325,11 @@ jobs:
         env:
           TWINE_USERNAME: __token__
           TWINE_PASSWORD: ${{ secrets.TEST_PYPI_API_TOKEN }}
-        run: python -m twine upload --repository-url https://test.pypi.org/legacy/ dist/*
+        run: python scripts/upload_python_release.py --repository testpypi dist/*
 
       - name: Upload stable distribution to PyPI
         if: steps.channel.outputs.prerelease == 'false'
         env:
           TWINE_USERNAME: __token__
           TWINE_PASSWORD: ${{ secrets.PYPI_API_TOKEN }}
-        run: python -m twine upload --repository-url https://upload.pypi.org/legacy/ dist/*
+        run: python scripts/upload_python_release.py --repository pypi dist/*

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,8 +6,26 @@ The format follows [Keep a Changelog](https://keepachangelog.com/), and versions
 
 ## [Unreleased]
 
+## [0.4.35-rc1] — 2026-08-20
+
+### Added
+- **DeepSeek Harness is now a first-class managed headless runtime.** CCCC installs the pinned ACP composition under `CCCC_HOME`, isolates provider sessions per actor, projects structured turn events, and keeps failed or interrupted delivery retryable without duplicating committed work.
+- **Optional membership and Reach are available as an explicit preview on Linux and macOS.** `cccc login`, `cccc logout`, and `cccc reach` bind a machine account, supervise a checksum-pinned `cloudflared`, and expose separately labeled Web and ChatGPT connector URLs without uploading the local ledger or repository.
+- **Windows project browsing now includes available drive roots**, allowing attached scopes to be selected outside the current drive from the Web UI.
+
+### Changed
+- **Runtime restoration and message delivery use stronger lifecycle boundaries.** Group restore is serialized with lifecycle mutations, large legacy headless histories migrate through bounded indexes, and delivery completion advances only across a contiguous committed prefix.
+- **Web task coordination and chat following were split into focused components.** Task Board controls, cards, columns, virtual-message anchoring, and send-follow behavior now avoid stale scroll requests and oversized container components.
+- **The combined Rust Web/daemon launcher owns only the Windows daemon process it created.** Startup waits through legacy-daemon handoff, shutdown leaves a replacement owner untouched, and failed Web startup cleans up the detached daemon before returning.
+
 ### Fixed
 - **Windows standalone updates and daemon recovery no longer fail on expected stopped-state diagnostics.** PowerShell 5.1 now checks daemon commands by process exit code without promoting native stderr into a terminating installer error, empty restart diagnostics are null-safe, and a verified replacement is retained when only runtime restart fails. The Rust daemon publishes IPC before restoring actors in a detached worker, serializes each Group restore with lifecycle mutations, and keeps slow or failed recovery diagnosable without blocking daemon readiness; stale unlocked daemon files continue to be reclaimed through the operating-system lock.
+- **DeepSeek delivery, recovery, timeout, and write-failure paths now preserve one durable outcome.** Turn and operation identities are bounded, pending work survives restarts, and a provider failure cannot silently advance the inbox cursor.
+- **Daemon process and ledger locks now fail safely across restart races.** Stale unlocked files are reclaimed, owned process trees are bounded, and competing daemon owners are not terminated during cleanup.
+
+### Tests
+- Added deterministic DeepSeek ACP, durability, recovery, timeout, projection, and setup coverage across Python and Rust.
+- Added membership, Reach, cloudflared supervision, cross-engine state, Windows updater, daemon handoff, process-tree, and combined Web startup-failure coverage.
 
 ## [0.4.34] — 2026-08-16
 

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -427,7 +427,7 @@ dependencies = [
 
 [[package]]
 name = "cccc"
-version = "0.4.34"
+version = "0.4.35-rc1"
 dependencies = [
  "anyhow",
  "cccc-pair-client",
@@ -449,7 +449,7 @@ dependencies = [
 
 [[package]]
 name = "cccc-pair-client"
-version = "0.4.34"
+version = "0.4.35-rc1"
 dependencies = [
  "cccc-pair-contracts",
  "cccc-pair-core",
@@ -460,7 +460,7 @@ dependencies = [
 
 [[package]]
 name = "cccc-pair-contracts"
-version = "0.4.34"
+version = "0.4.35-rc1"
 dependencies = [
  "chrono",
  "serde",
@@ -470,7 +470,7 @@ dependencies = [
 
 [[package]]
 name = "cccc-pair-core"
-version = "0.4.34"
+version = "0.4.35-rc1"
 dependencies = [
  "aws-lc-rs",
  "base64",
@@ -497,7 +497,7 @@ dependencies = [
 
 [[package]]
 name = "cccc-pair-daemon"
-version = "0.4.34"
+version = "0.4.35-rc1"
 dependencies = [
  "anyhow",
  "base64",
@@ -534,7 +534,7 @@ dependencies = [
 
 [[package]]
 name = "cccc-pair-mcp"
-version = "0.4.34"
+version = "0.4.35-rc1"
 dependencies = [
  "anyhow",
  "axum",
@@ -559,7 +559,7 @@ dependencies = [
 
 [[package]]
 name = "cccc-pair-notebooklm"
-version = "0.4.34"
+version = "0.4.35-rc1"
 dependencies = [
  "cookie",
  "regex",
@@ -571,7 +571,7 @@ dependencies = [
 
 [[package]]
 name = "cccc-pair-runtime"
-version = "0.4.34"
+version = "0.4.35-rc1"
 dependencies = [
  "cccc-pair-contracts",
  "nix",
@@ -606,7 +606,7 @@ dependencies = [
 
 [[package]]
 name = "cccc-pair-web"
-version = "0.4.34"
+version = "0.4.35-rc1"
 dependencies = [
  "aes",
  "anyhow",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -18,7 +18,7 @@ exclude = [
 ]
 
 [workspace.package]
-version = "0.4.34"
+version = "0.4.35-rc1"
 edition = "2024"
 license = "Apache-2.0"
 repository = "https://github.com/ChesterRa/cccc"

--- a/crates/cccc-cli/Cargo.toml
+++ b/crates/cccc-cli/Cargo.toml
@@ -20,13 +20,13 @@ standalone = ["dep:openssl-sys"]
 
 [dependencies]
 anyhow.workspace = true
-cccc-client = { package = "cccc-pair-client", version = "=0.4.34", path = "../cccc-client" }
-cccc-contracts = { package = "cccc-pair-contracts", version = "=0.4.34", path = "../cccc-contracts" }
-cccc-core = { package = "cccc-pair-core", version = "=0.4.34", path = "../cccc-core" }
-cccc-daemon = { package = "cccc-pair-daemon", version = "=0.4.34", path = "../cccc-daemon" }
-cccc-mcp = { package = "cccc-pair-mcp", version = "=0.4.34", path = "../cccc-mcp" }
-cccc-runtime = { package = "cccc-pair-runtime", version = "=0.4.34", path = "../cccc-runtime" }
-cccc-web = { package = "cccc-pair-web", version = "=0.4.34", path = "../cccc-web" }
+cccc-client = { package = "cccc-pair-client", version = "=0.4.35-rc1", path = "../cccc-client" }
+cccc-contracts = { package = "cccc-pair-contracts", version = "=0.4.35-rc1", path = "../cccc-contracts" }
+cccc-core = { package = "cccc-pair-core", version = "=0.4.35-rc1", path = "../cccc-core" }
+cccc-daemon = { package = "cccc-pair-daemon", version = "=0.4.35-rc1", path = "../cccc-daemon" }
+cccc-mcp = { package = "cccc-pair-mcp", version = "=0.4.35-rc1", path = "../cccc-mcp" }
+cccc-runtime = { package = "cccc-pair-runtime", version = "=0.4.35-rc1", path = "../cccc-runtime" }
+cccc-web = { package = "cccc-pair-web", version = "=0.4.35-rc1", path = "../cccc-web" }
 clap.workspace = true
 fs2.workspace = true
 reqwest.workspace = true

--- a/crates/cccc-cli/src/detached_daemon_owner.rs
+++ b/crates/cccc-cli/src/detached_daemon_owner.rs
@@ -1,0 +1,127 @@
+#[cfg(windows)]
+use anyhow::{Result, bail};
+#[cfg(windows)]
+use cccc_client::DaemonClient;
+#[cfg(windows)]
+use cccc_core::HomeLayout;
+#[cfg(windows)]
+use cccc_daemon::{DetachedDaemon, StartOutcome};
+
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+enum Ownership {
+    Owned,
+    NotRunning,
+    Replaced,
+}
+
+fn ownership(owned_pid: u32, running_pid: Option<u32>) -> Ownership {
+    match running_pid {
+        Some(running_pid) if running_pid == owned_pid => Ownership::Owned,
+        Some(_) => Ownership::Replaced,
+        None => Ownership::NotRunning,
+    }
+}
+
+#[cfg(windows)]
+pub(crate) struct OwnedDetachedDaemon {
+    pid: u32,
+}
+
+#[cfg(windows)]
+impl OwnedDetachedDaemon {
+    pub(crate) async fn start(home: &HomeLayout, client: &DaemonClient) -> Result<Option<Self>> {
+        let deadline = tokio::time::Instant::now() + std::time::Duration::from_secs(30);
+        loop {
+            if super::ping(client).await {
+                return Ok(None);
+            }
+
+            let executable = std::env::current_exe()?;
+            match DetachedDaemon::new(executable, ["daemon", "run"])
+                .start(home)
+                .await?
+            {
+                StartOutcome::Started(pid) => {
+                    let owner = Self { pid };
+                    if super::wait_for_compatible_daemon(client, deadline).await {
+                        return Ok(Some(owner));
+                    }
+                    let cleanup = owner.stop(client, home).await;
+                    if let Err(error) = cleanup {
+                        bail!(
+                            "Rust daemon failed to become compatible and cleanup failed: {error}; see {}",
+                            home.daemon_dir().join("ccccd.log").display()
+                        );
+                    }
+                    bail!(
+                        "Rust daemon failed to become compatible; see {}",
+                        home.daemon_dir().join("ccccd.log").display()
+                    );
+                }
+                StartOutcome::AlreadyRunning => {
+                    if tokio::time::Instant::now() >= deadline {
+                        bail!(
+                            "existing daemon did not hand off to the Rust daemon; see {}",
+                            home.daemon_dir().join("ccccd.log").display()
+                        );
+                    }
+                    tokio::time::sleep(std::time::Duration::from_millis(100)).await;
+                }
+            }
+        }
+    }
+
+    pub(crate) async fn stop(&self, client: &DaemonClient, home: &HomeLayout) -> Result<()> {
+        match ownership(self.pid, super::running_daemon_pid(client).await) {
+            Ownership::Replaced => return Ok(()),
+            Ownership::Owned => {
+                if super::stop_daemon(client, home)
+                    .await
+                    .is_ok_and(|response| response.ok)
+                {
+                    return Ok(());
+                }
+            }
+            Ownership::NotRunning => {}
+        }
+
+        let pid = self.pid.to_string();
+        let output = std::process::Command::new("taskkill")
+            .args(["/PID", pid.as_str(), "/T", "/F"])
+            .output()
+            .map_err(|error| {
+                anyhow::anyhow!("failed to run taskkill for daemon {}: {error}", self.pid)
+            })?;
+
+        if matches!(
+            ownership(self.pid, super::running_daemon_pid(client).await),
+            Ownership::Replaced
+        ) {
+            return Ok(());
+        }
+        if !output.status.success()
+            && super::wait_for_daemon_lock_release(home, std::time::Duration::from_millis(100))
+                .await
+                .is_err()
+        {
+            bail!(
+                "failed to terminate daemon {}: {}",
+                self.pid,
+                String::from_utf8_lossy(&output.stderr).trim()
+            );
+        }
+        super::wait_for_daemon_lock_release(home, super::DAEMON_SHUTDOWN_TIMEOUT).await
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::{Ownership, ownership};
+
+    #[test]
+    fn only_the_spawned_daemon_is_owned() {
+        assert_eq!(ownership(41, Some(41)), Ownership::Owned);
+        assert_eq!(ownership(41, None), Ownership::NotRunning);
+        assert_eq!(ownership(41, Some(42)), Ownership::Replaced);
+    }
+}

--- a/crates/cccc-cli/src/main.rs
+++ b/crates/cccc-cli/src/main.rs
@@ -1,5 +1,7 @@
 mod args;
 mod commands;
+#[cfg(any(windows, test))]
+mod detached_daemon_owner;
 mod hook_receiver;
 mod shutdown;
 mod web_instance;
@@ -140,49 +142,51 @@ async fn launch(
     instance.hold_until_process_exit();
     replace_incompatible_daemon(&home, &client).await?;
     let mut embedded_daemon = None;
-    #[cfg(windows)]
-    let mut detached_daemon_owned = false;
     // Event-driven loss detection for the embedded daemon: polling in
     // `wait_for_daemon_loss` stays as the fallback for an external daemon.
     #[cfg(windows)]
     let (_daemon_exit_tx, daemon_exit_rx) = tokio::sync::watch::channel(false);
     #[cfg(not(windows))]
     let (daemon_exit_tx, mut daemon_exit_rx) = tokio::sync::watch::channel(false);
-    if !ping(&client).await {
+    let daemon_missing = !ping(&client).await;
+    #[cfg(windows)]
+    let detached_daemon = if daemon_missing {
         // Running the daemon as a task inside the Web host is unreliable on
         // Windows once the daemon installs its kill-on-close Job object. In
         // particular, hosts launched through `cargo run` can fail to publish a
         // ready daemon and then hang while the task is cancelled. The existing
         // detached launcher gives the daemon its own process and Job lifetime.
-        #[cfg(windows)]
-        {
-            let executable = std::env::current_exe()?;
-            detached_daemon_owned = matches!(
-                DetachedDaemon::new(executable, ["daemon", "run"])
-                    .start(&home)
-                    .await?,
-                StartOutcome::Started(_)
-            );
-        }
-        #[cfg(not(windows))]
-        {
-            let daemon_home = home.clone();
-            embedded_daemon = Some(tokio::spawn(async move {
-                let result = cccc_daemon::run(daemon_home).await;
-                let _ = daemon_exit_tx.send(true);
-                result
-            }));
-            let _ = wait_for_daemon(
-                &client,
-                &mut daemon_exit_rx,
-                std::time::Duration::from_secs(30),
-            )
-            .await;
-        }
+        detached_daemon_owner::OwnedDetachedDaemon::start(&home, &client).await?
+    } else {
+        None
+    };
+    #[cfg(not(windows))]
+    if daemon_missing {
+        let daemon_home = home.clone();
+        embedded_daemon = Some(tokio::spawn(async move {
+            let result = cccc_daemon::run(daemon_home).await;
+            let _ = daemon_exit_tx.send(true);
+            result
+        }));
+        let _ = wait_for_daemon(
+            &client,
+            &mut daemon_exit_rx,
+            std::time::Duration::from_secs(30),
+        )
+        .await;
     }
     if !ping(&client).await {
+        #[cfg(windows)]
+        if let Some(owner) = detached_daemon.as_ref()
+            && let Err(error) = owner.stop(&client, &home).await
+        {
+            eprintln!("failed to stop Web-owned daemon after startup failure: {error}");
+        }
         finish_embedded_daemon(&client, embedded_daemon.take()).await;
-        bail!("embedded Rust daemon failed to start");
+        bail!(
+            "Rust daemon failed to become ready; see {}",
+            home.daemon_dir().join("ccccd.log").display()
+        );
     }
     let shutdown_watchdog = tokio::spawn(shutdown::watch_for_interrupt());
     let mode = web_mode.unwrap_or_else(cccc_web::WebMode::from_env);
@@ -223,7 +227,9 @@ async fn launch(
     };
     cccc_mcp::shutdown(&home).await;
     #[cfg(windows)]
-    if detached_daemon_owned && let Err(error) = stop_daemon(&client, &home).await {
+    if let Some(owner) = detached_daemon.as_ref()
+        && let Err(error) = owner.stop(&client, &home).await
+    {
         eprintln!("failed to stop Web-owned daemon: {error}");
     }
     finish_embedded_daemon(&client, embedded_daemon.take()).await;
@@ -403,6 +409,19 @@ async fn ping(client: &DaemonClient) -> bool {
     call(client, "ping", json!({}))
         .await
         .is_ok_and(|response| is_compatible_daemon(&response))
+}
+
+#[cfg(windows)]
+async fn wait_for_compatible_daemon(client: &DaemonClient, deadline: tokio::time::Instant) -> bool {
+    loop {
+        if ping(client).await {
+            return true;
+        }
+        if tokio::time::Instant::now() >= deadline {
+            return false;
+        }
+        tokio::time::sleep(std::time::Duration::from_millis(100)).await;
+    }
 }
 
 #[cfg(any(not(windows), test))]

--- a/crates/cccc-cli/tests/suite/daemon_self_launch.rs
+++ b/crates/cccc-cli/tests/suite/daemon_self_launch.rs
@@ -86,6 +86,31 @@ fn daemon_stop_waits_for_the_combined_web_process_to_exit() {
     assert_web_lock_released(&home);
 }
 
+#[test]
+fn combined_web_bind_failure_stops_its_owned_daemon() {
+    let temp = tempfile::tempdir().expect("tempdir");
+    let installed = temp.path().join(executable_name("cccc"));
+    std::fs::copy(env!("CARGO_BIN_EXE_cccc"), &installed).expect("copy cccc");
+    let home = temp.path().join("home");
+    let occupied = std::net::TcpListener::bind(("127.0.0.1", 0)).expect("occupy Web port");
+    let port = occupied.local_addr().expect("occupied address").port();
+
+    let output = run(
+        &installed,
+        &home,
+        &["--host", "127.0.0.1", "--port", &port.to_string()],
+    );
+
+    assert!(
+        !output.status.success(),
+        "combined CCCC unexpectedly served an occupied port: {}",
+        detail(&output)
+    );
+    wait_for_daemon_exit(&home);
+    assert_daemon_lock_released(&home);
+    assert_web_lock_released(&home);
+}
+
 fn assert_daemon_lock_released(home: &Path) {
     let lock_path = home.join("daemon").join("ccccd.lock");
     let lock = OpenOptions::new()

--- a/crates/cccc-client/Cargo.toml
+++ b/crates/cccc-client/Cargo.toml
@@ -9,8 +9,8 @@ description = "IPC client for the CCCC collaborative agent control plane"
 publish = false
 
 [dependencies]
-cccc-contracts = { package = "cccc-pair-contracts", version = "=0.4.34", path = "../cccc-contracts" }
-cccc-core = { package = "cccc-pair-core", version = "=0.4.34", path = "../cccc-core" }
+cccc-contracts = { package = "cccc-pair-contracts", version = "=0.4.35-rc1", path = "../cccc-contracts" }
+cccc-core = { package = "cccc-pair-core", version = "=0.4.35-rc1", path = "../cccc-core" }
 serde_json.workspace = true
 thiserror.workspace = true
 tokio.workspace = true

--- a/crates/cccc-core/Cargo.toml
+++ b/crates/cccc-core/Cargo.toml
@@ -11,7 +11,7 @@ publish = false
 [dependencies]
 aws-lc-rs.workspace = true
 base64.workspace = true
-cccc-contracts = { package = "cccc-pair-contracts", version = "=0.4.34", path = "../cccc-contracts" }
+cccc-contracts = { package = "cccc-pair-contracts", version = "=0.4.35-rc1", path = "../cccc-contracts" }
 chrono.workspace = true
 chrono-tz.workspace = true
 cron.workspace = true

--- a/crates/cccc-daemon/Cargo.toml
+++ b/crates/cccc-daemon/Cargo.toml
@@ -11,11 +11,11 @@ publish = false
 [dependencies]
 anyhow.workspace = true
 base64.workspace = true
-cccc-client = { package = "cccc-pair-client", version = "=0.4.34", path = "../cccc-client" }
-cccc-contracts = { package = "cccc-pair-contracts", version = "=0.4.34", path = "../cccc-contracts" }
-cccc-core = { package = "cccc-pair-core", version = "=0.4.34", path = "../cccc-core" }
-cccc-notebooklm = { package = "cccc-pair-notebooklm", version = "=0.4.34", path = "../cccc-notebooklm" }
-cccc-runtime = { package = "cccc-pair-runtime", version = "=0.4.34", path = "../cccc-runtime" }
+cccc-client = { package = "cccc-pair-client", version = "=0.4.35-rc1", path = "../cccc-client" }
+cccc-contracts = { package = "cccc-pair-contracts", version = "=0.4.35-rc1", path = "../cccc-contracts" }
+cccc-core = { package = "cccc-pair-core", version = "=0.4.35-rc1", path = "../cccc-core" }
+cccc-notebooklm = { package = "cccc-pair-notebooklm", version = "=0.4.35-rc1", path = "../cccc-notebooklm" }
+cccc-runtime = { package = "cccc-pair-runtime", version = "=0.4.35-rc1", path = "../cccc-runtime" }
 chrono.workspace = true
 clap.workspace = true
 fs2.workspace = true

--- a/crates/cccc-mcp/Cargo.toml
+++ b/crates/cccc-mcp/Cargo.toml
@@ -11,10 +11,10 @@ publish = false
 [dependencies]
 anyhow.workspace = true
 base64.workspace = true
-cccc-client = { package = "cccc-pair-client", version = "=0.4.34", path = "../cccc-client" }
-cccc-contracts = { package = "cccc-pair-contracts", version = "=0.4.34", path = "../cccc-contracts" }
-cccc-core = { package = "cccc-pair-core", version = "=0.4.34", path = "../cccc-core" }
-cccc-runtime = { package = "cccc-pair-runtime", version = "=0.4.34", path = "../cccc-runtime" }
+cccc-client = { package = "cccc-pair-client", version = "=0.4.35-rc1", path = "../cccc-client" }
+cccc-contracts = { package = "cccc-pair-contracts", version = "=0.4.35-rc1", path = "../cccc-contracts" }
+cccc-core = { package = "cccc-pair-core", version = "=0.4.35-rc1", path = "../cccc-core" }
+cccc-runtime = { package = "cccc-pair-runtime", version = "=0.4.35-rc1", path = "../cccc-runtime" }
 chrono.workspace = true
 regex.workspace = true
 reqwest.workspace = true
@@ -28,7 +28,7 @@ uuid.workspace = true
 
 [dev-dependencies]
 axum.workspace = true
-cccc-daemon = { package = "cccc-pair-daemon", version = "=0.4.34", path = "../cccc-daemon" }
+cccc-daemon = { package = "cccc-pair-daemon", version = "=0.4.35-rc1", path = "../cccc-daemon" }
 tempfile.workspace = true
 
 [lints]

--- a/crates/cccc-runtime/Cargo.toml
+++ b/crates/cccc-runtime/Cargo.toml
@@ -9,7 +9,7 @@ description = "Process and terminal runtime management for CCCC"
 publish = false
 
 [dependencies]
-cccc-contracts = { package = "cccc-pair-contracts", version = "=0.4.34", path = "../cccc-contracts" }
+cccc-contracts = { package = "cccc-pair-contracts", version = "=0.4.35-rc1", path = "../cccc-contracts" }
 portable-pty.workspace = true
 retach.workspace = true
 serde.workspace = true

--- a/crates/cccc-web/Cargo.toml
+++ b/crates/cccc-web/Cargo.toml
@@ -22,11 +22,11 @@ async-trait.workspace = true
 axum.workspace = true
 base64.workspace = true
 bzip2.workspace = true
-cccc-client = { package = "cccc-pair-client", version = "=0.4.34", path = "../cccc-client" }
-cccc-contracts = { package = "cccc-pair-contracts", version = "=0.4.34", path = "../cccc-contracts" }
-cccc-core = { package = "cccc-pair-core", version = "=0.4.34", path = "../cccc-core" }
-cccc-mcp = { package = "cccc-pair-mcp", version = "=0.4.34", path = "../cccc-mcp" }
-cccc-runtime = { package = "cccc-pair-runtime", version = "=0.4.34", path = "../cccc-runtime" }
+cccc-client = { package = "cccc-pair-client", version = "=0.4.35-rc1", path = "../cccc-client" }
+cccc-contracts = { package = "cccc-pair-contracts", version = "=0.4.35-rc1", path = "../cccc-contracts" }
+cccc-core = { package = "cccc-pair-core", version = "=0.4.35-rc1", path = "../cccc-core" }
+cccc-mcp = { package = "cccc-pair-mcp", version = "=0.4.35-rc1", path = "../cccc-mcp" }
+cccc-runtime = { package = "cccc-pair-runtime", version = "=0.4.35-rc1", path = "../cccc-runtime" }
 chromiumoxide.workspace = true
 chrono.workspace = true
 crc32fast.workspace = true
@@ -65,7 +65,7 @@ url.workspace = true
 weixin-agent.workspace = true
 
 [dev-dependencies]
-cccc-daemon = { package = "cccc-pair-daemon", version = "=0.4.34", path = "../cccc-daemon" }
+cccc-daemon = { package = "cccc-pair-daemon", version = "=0.4.35-rc1", path = "../cccc-daemon" }
 http-body-util.workspace = true
 tower.workspace = true
 

--- a/docs/.vitepress/config.ts
+++ b/docs/.vitepress/config.ts
@@ -6,7 +6,18 @@ import { defineConfig, type DefaultTheme, HeadConfig } from 'vitepress'
 const DOCS_DIR = resolve(dirname(fileURLToPath(import.meta.url)), '..')
 
 function compareSemverDesc(a: string, b: string): number {
-  const parse = (version: string) => version.split('.').map((part) => Number(part) || 0)
+  const parse = (version: string) => {
+    const match = /^(\d+)\.(\d+)\.(\d+)(?:-(alpha|beta|rc)(\d+))?$/.exec(version)
+    if (!match) return [0, 0, 0, 0, 0]
+    const phase = { alpha: 1, beta: 2, rc: 3 }
+    return [
+      Number(match[1]),
+      Number(match[2]),
+      Number(match[3]),
+      match[4] ? phase[match[4] as keyof typeof phase] : 4,
+      Number(match[5] || 0),
+    ]
+  }
   const left = parse(a)
   const right = parse(b)
   for (let index = 0; index < Math.max(left.length, right.length); index += 1) {
@@ -19,7 +30,9 @@ function compareSemverDesc(a: string, b: string): number {
 function buildReleaseSidebarItems(): DefaultTheme.SidebarItem[] {
   const releaseDir = resolve(DOCS_DIR, 'release')
   const releaseItems = readdirSync(releaseDir)
-    .map((fileName) => /^v(\d+\.\d+\.\d+)_release_notes\.md$/.exec(fileName))
+    .map((fileName) =>
+      /^v(\d+\.\d+\.\d+(?:-(?:alpha|beta|rc)\d+)?)_release_notes\.md$/.exec(fileName),
+    )
     .filter((match): match is RegExpExecArray => !!match)
     .map((match) => ({
       version: match[1],

--- a/docs/guide/quality-gates.md
+++ b/docs/guide/quality-gates.md
@@ -96,7 +96,7 @@ Vite+ 0.2.4 / tsgolint 0.24 does not yet replace this project's `tsc` gate. Enab
 | `rust-test` | Python-free Rust workspace plus installer/release source contracts |
 | `rust-process-lifecycle` | Serial combined daemon/Web lifecycle tests, isolated from the parallel workspace suite |
 | `interop` | Focused Python/Rust persisted-state and lock compatibility tests |
-| `windows-smoke` | Windows PTY compatibility tests plus forced daemon Job Object process-tree cleanup |
+| `windows-smoke` | Windows PTY compatibility, combined Web startup-failure cleanup, and forced daemon Job Object process-tree cleanup |
 | `ci-required` | Stable aggregate result for branch protection; fails when any required job fails or is skipped |
 
 The Rust pull-request jobs are self-contained: they do not install or execute

--- a/docs/reference/cli.md
+++ b/docs/reference/cli.md
@@ -57,6 +57,26 @@ Notes:
 - `cccc daemon start` refuses to spawn a duplicate daemon if the pid-file process is still alive but IPC is not responding.
 - In that case, run `cccc daemon stop` (or clean stale runtime state) before retrying start.
 
+## Membership and Reach Commands
+
+Membership is optional. Local CCCC remains usable without an account. Reach is
+a Linux/macOS preview and requires an Admin Access Token in **Settings > Web
+Access** before publishing the local Web surface.
+
+```bash
+cccc login             # Bind this machine through device authorization
+cccc logout            # Remove the local membership identity
+cccc reach install     # Install or upgrade the pinned cloudflared helper
+cccc reach on          # Publish the authenticated Web surface
+cccc reach status      # Show account, hostname, Web, and connector state
+cccc reach off         # Stop publication without removing local identity
+```
+
+The Web URL and ChatGPT connector URL are distinct secrets. Rotating a token,
+cutting access, or logging out changes the connector URL. Windows helper
+installation is not included in this release candidate, so Reach is unavailable
+there.
+
 ## Group Commands
 
 ### `cccc attach`

--- a/docs/release/index.md
+++ b/docs/release/index.md
@@ -4,7 +4,18 @@ import { withBase } from 'vitepress'
 const releaseModules = import.meta.glob('./v*_release_notes.md')
 
 function compareSemverDesc(a, b) {
-  const parse = (version) => version.split('.').map((part) => Number(part) || 0)
+  const parse = (version) => {
+    const match = /^(\d+)\.(\d+)\.(\d+)(?:-(alpha|beta|rc)(\d+))?$/.exec(version)
+    if (!match) return [0, 0, 0, 0, 0]
+    const phase = { alpha: 1, beta: 2, rc: 3 }
+    return [
+      Number(match[1]),
+      Number(match[2]),
+      Number(match[3]),
+      match[4] ? phase[match[4]] : 4,
+      Number(match[5] || 0),
+    ]
+  }
   const left = parse(a)
   const right = parse(b)
   for (let index = 0; index < Math.max(left.length, right.length); index += 1) {
@@ -15,7 +26,9 @@ function compareSemverDesc(a, b) {
 }
 
 const releases = Object.keys(releaseModules)
-  .map((fileName) => /^\.\/v(\d+\.\d+\.\d+)_release_notes\.md$/.exec(fileName))
+  .map((fileName) =>
+    /^\.\/v(\d+\.\d+\.\d+(?:-(?:alpha|beta|rc)\d+)?)_release_notes\.md$/.exec(fileName),
+  )
   .filter(Boolean)
   .map((match) => ({
     version: match[1],

--- a/docs/release/v0.4.35-rc1_release_notes.md
+++ b/docs/release/v0.4.35-rc1_release_notes.md
@@ -1,0 +1,113 @@
+# CCCC v0.4.35-rc1 Release Notes
+
+`v0.4.35-rc1` is the first release candidate for CCCC 0.4.35. It focuses on
+managed DeepSeek headless execution, optional membership and Reach, reliable
+cross-platform daemon ownership, and a broad delivery and Web interaction
+hardening pass.
+
+This is a prerelease. The hosted standalone installer and normal PyPI channel
+remain pinned to stable `v0.4.34`; RC users must select this version explicitly.
+
+## Highlights
+
+### Managed DeepSeek Harness runtime
+
+DeepSeek Harness is now a first-class `deepseek` headless runtime. CCCC installs
+the exact tested ACP package composition below `CCCC_HOME`, keeps provider
+credentials as external inputs, isolates sessions per actor, and projects ACP
+turns into the same durable headless events used by other runtimes.
+
+Delivery and recovery are designed around one durable outcome. Pending work can
+survive daemon restarts, committed turns are deduplicated, timed-out work is
+cancelled before retry, and failed writes do not silently advance inbox state.
+
+### Membership and Reach preview
+
+Linux and macOS users can bind a machine to a membership account and explicitly
+publish its Web surface through a managed Cloudflare tunnel:
+
+```bash
+cccc login
+cccc reach install
+cccc reach on
+cccc reach status
+cccc reach off
+cccc logout
+```
+
+Reach requires an Admin Access Token and keeps local CCCC usable without an
+account. Its pinned `cloudflared` helper lives under `CCCC_HOME`; CCCC does not
+upload the local ledger or repository. Windows process supervision is present,
+but the pinned Windows helper artifact is not included in this candidate, so
+Reach remains unavailable on Windows.
+
+### Windows daemon and updater reliability
+
+The combined Rust launcher now treats the detached Windows daemon as an owned
+resource. It waits for an incompatible or legacy daemon to hand off, records the
+PID it actually created, stops only that owner during normal or failed Web
+startup, and leaves a competing replacement daemon untouched. Graceful shutdown
+is attempted first; an exact-PID process-tree termination is retained as the
+bounded fallback.
+
+Windows standalone updates also use native process exit codes for expected
+stopped-state diagnostics, retain a verified replacement when only restart
+fails, and wait for executable and daemon-lock release before reporting success.
+
+### Runtime, delivery, and Web hardening
+
+- Runtime restoration is serialized with actor and Group lifecycle mutations.
+- Headless delivery completion advances only over a contiguous committed prefix.
+- Legacy large event histories migrate through bounded indexes.
+- Windows project selection can browse available drive roots.
+- Task Board and virtual chat scrolling use focused components and stale-request
+  guards, improving send-follow and history-anchor stability.
+
+## Install the release candidate
+
+Python compatibility and native wheels are published to TestPyPI:
+
+```bash
+python -m pip install -U --pre \
+  --index-url https://test.pypi.org/simple/ \
+  --extra-index-url https://pypi.org/simple/ \
+  'cccc-pair==0.4.35rc1'
+```
+
+The standalone Rust candidate is selected explicitly from GitHub Releases:
+
+```bash
+curl -fsSL https://chesterra.github.io/cccc/install.sh | \
+  CCCC_VERSION=0.4.35-rc1 sh
+```
+
+```powershell
+$env:CCCC_VERSION = "0.4.35-rc1"
+powershell.exe -NoProfile -ExecutionPolicy Bypass -Command "[Net.ServicePointManager]::SecurityProtocol = [Net.ServicePointManager]::SecurityProtocol -bor [Net.SecurityProtocolType]::Tls12; Invoke-RestMethod 'https://chesterra.github.io/cccc/install.ps1' | Invoke-Expression"
+Remove-Item Env:CCCC_VERSION
+```
+
+Verify the installed identity and lifecycle:
+
+```bash
+cccc --version
+cccc status
+cccc daemon status
+cccc daemon stop
+```
+
+## Compatibility and known limits
+
+- Python 3.11 through 3.14 remain supported.
+- Linux x86-64, Intel macOS, Apple Silicon macOS, and Windows x86-64 receive
+  native candidates; the portable wheel remains Python-only.
+- Existing `CCCC_HOME` Groups, ledgers, settings, and runtime state remain shared
+  between Python and Rust. Back up operational data before prerelease testing.
+- Reach is a Linux/macOS preview and is unavailable on Windows in this candidate.
+- DeepSeek requires a valid provider credential and uses an upstream developer
+  preview package set; live-provider behavior cannot be proven by offline CI.
+- The standalone Rust distribution has no Python fallback or implementation
+  switching. Use the pip distribution when that fallback is required.
+
+Any code or artifact correction after this candidate will be published as
+`v0.4.35-rc2`; the `v0.4.35-rc1` tag and artifacts will not be replaced.

--- a/docs/rust-migration.md
+++ b/docs/rust-migration.md
@@ -26,9 +26,9 @@ to pass, together with measured operational value relative to maintenance cost.
 Rust promotion does not imply Python retirement; changing the default engine or
 retiring an implementation is a separate product decision.
 
-Prereleases use one canonical product identity and tag such as `v0.4.34-rc2`.
-The Python manifest represents that identity as PEP 440 `0.4.34rc2`, while the
-Cargo workspace uses SemVer `0.4.34-rc2`; release validation normalizes those
+Prereleases use one canonical product identity and tag such as `v0.4.35-rc1`.
+The Python manifest represents that identity as PEP 440 `0.4.35rc1`, while the
+Cargo workspace uses SemVer `0.4.35-rc1`; release validation normalizes those
 ecosystem-specific spellings before comparing them.
 
 ## Install and update

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "setuptools.build_meta"
 
 [project]
 name = "cccc-pair"
-version = "0.4.34"
+version = "0.4.35rc1"
 description = "Global multi-agent delivery kernel with working groups, scopes, and an append-only collaboration ledger"
 readme = { file = "README.md", content-type = "text/markdown" }
 requires-python = ">=3.11"

--- a/scripts/install.ps1
+++ b/scripts/install.ps1
@@ -144,10 +144,14 @@ function Invoke-CcccCommand(
       throw "$CommandPath $($Arguments -join ' ') timed out"
     }
     $process.WaitForExit()
+    # A successfully detached daemon can inherit these pipe handles after the
+    # launcher exits. Do not wait forever for EOF from that child process.
+    $stdout = if ($stdoutTask.Wait(1000)) { [string]$stdoutTask.Result } else { "" }
+    $stderr = if ($stderrTask.Wait(1000)) { [string]$stderrTask.Result } else { "" }
     return [PSCustomObject]@{
       ExitCode = $process.ExitCode
-      Stdout = [string]$stdoutTask.Result
-      Stderr = [string]$stderrTask.Result
+      Stdout = $stdout
+      Stderr = $stderr
     }
   } finally {
     $process.Dispose()

--- a/scripts/upload_python_release.py
+++ b/scripts/upload_python_release.py
@@ -1,0 +1,78 @@
+#!/usr/bin/env python3
+"""Upload only Python release files that are not already on the target index."""
+
+from __future__ import annotations
+
+import argparse
+import json
+import subprocess
+import sys
+import urllib.error
+import urllib.request
+from pathlib import Path
+
+
+_REPOSITORIES = {
+    "pypi": ("https://pypi.org/pypi", "https://upload.pypi.org/legacy/"),
+    "testpypi": ("https://test.pypi.org/pypi", "https://test.pypi.org/legacy/"),
+}
+_PROJECT = "cccc-pair"
+
+
+def existing_filenames(repository: str) -> set[str]:
+    index_url, _ = _REPOSITORIES[repository]
+    request = urllib.request.Request(
+        f"{index_url}/{_PROJECT}/json",
+        headers={"Accept": "application/json"},
+    )
+    try:
+        with urllib.request.urlopen(request, timeout=30) as response:
+            payload = json.load(response)
+    except urllib.error.HTTPError as error:
+        if error.code == 404:
+            return set()
+        raise
+    return {
+        str(item["filename"])
+        for release in payload.get("releases", {}).values()
+        for item in release
+        if item.get("filename")
+    }
+
+
+def upload_missing(repository: str, distributions: list[Path]) -> int:
+    missing = [path for path in distributions if path.name not in existing_filenames(repository)]
+    if not missing:
+        print(f"All {_PROJECT} distributions already exist on {repository}; nothing to upload.")
+        return 0
+
+    _, upload_url = _REPOSITORIES[repository]
+    completed = subprocess.run(
+        [
+            sys.executable,
+            "-m",
+            "twine",
+            "upload",
+            "--skip-existing",
+            "--repository-url",
+            upload_url,
+            *(str(path) for path in missing),
+        ],
+        check=False,
+    )
+    return completed.returncode
+
+
+def main() -> int:
+    parser = argparse.ArgumentParser()
+    parser.add_argument("--repository", choices=sorted(_REPOSITORIES), required=True)
+    parser.add_argument("distributions", nargs="+", type=Path)
+    args = parser.parse_args()
+    missing_files = [path for path in args.distributions if not path.is_file()]
+    if missing_files:
+        parser.error(f"distribution does not exist: {missing_files[0]}")
+    return upload_missing(args.repository, args.distributions)
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/tests/test_quality_ci_workflow.py
+++ b/tests/test_quality_ci_workflow.py
@@ -60,7 +60,7 @@ def test_ci_has_read_only_permissions_bounded_jobs_and_cancels_stale_runs() -> N
         "python-tests": "25",
         "python-compat": "15",
         "package": "25",
-        "windows-smoke": "20",
+        "windows-smoke": "30",
         "rust-lint": "15",
         "rust-test": "45",
         "rust-process-lifecycle": "15",
@@ -187,6 +187,12 @@ def test_rust_jobs_are_python_free_and_serialize_daemon_tests() -> None:
     assert "--test-threads=1" in lifecycle_runs
     assert "cargo fmt --all --check" in _runs(jobs["rust-lint"])
     assert "cargo clippy --workspace --all-targets -- -D warnings" in _runs(jobs["rust-lint"])
+    windows_runs = _runs(jobs["windows-smoke"])
+    assert "cargo test --package cccc --test integration --locked" in windows_runs
+    assert (
+        "daemon_self_launch::combined_web_bind_failure_stops_its_owned_daemon"
+        in windows_runs
+    )
 
 
 def test_python_backed_rust_tests_share_one_explicit_ci_category() -> None:

--- a/tests/test_quality_ci_workflow.py
+++ b/tests/test_quality_ci_workflow.py
@@ -466,7 +466,7 @@ def test_python_release_builds_one_atomic_dual_implementation_set() -> None:
     assert "delocate==0.13.0" in release_runs
     assert "delvewheel==1.13.0" in release_runs
     assert "scripts/verify_python_release_set.py dist" in collect_runs
-    assert "python -m twine upload" in _runs(jobs["publish"])
+    assert "scripts/upload_python_release.py" in _runs(jobs["publish"])
     assert "cccc rust" not in release_runs
     for source_test in ("cargo test", "pytest", "context_python_interop", "python_storage_interop"):
         assert source_test not in release_runs
@@ -491,7 +491,7 @@ def test_product_tag_publishes_pypi_and_standalone_preview() -> None:
     assert "delocate==0.13.0" in release_runs
     assert "delvewheel==1.13.0" in release_runs
     assert "scripts/publish_rust_crates.sh --publish" not in release_runs
-    assert "python -m twine upload" in _runs(release["jobs"]["publish"])
+    assert "scripts/upload_python_release.py" in _runs(release["jobs"]["publish"])
 
     assert set(rust_candidate["on"]) == {"push", "workflow_dispatch"}
     assert rust_candidate["on"]["push"]["tags"] == ["v*"]
@@ -582,7 +582,11 @@ def test_product_tag_publishes_pypi_and_standalone_preview() -> None:
 def test_python_release_keeps_registry_tokens_out_of_step_outputs() -> None:
     publish = _release_workflow()["jobs"]["publish"]
     classify = next(step for step in publish["steps"] if step.get("id") == "channel")
-    uploads = [step for step in publish["steps"] if "twine upload" in step.get("run", "")]
+    uploads = [
+        step
+        for step in publish["steps"]
+        if "upload_python_release.py" in step.get("run", "")
+    ]
 
     assert "secrets." not in classify["run"]
     assert "token=" not in classify["run"]
@@ -593,6 +597,10 @@ def test_python_release_keeps_registry_tokens_out_of_step_outputs() -> None:
     assert {step["env"]["TWINE_PASSWORD"] for step in uploads} == {
         "${{ secrets.TEST_PYPI_API_TOKEN }}",
         "${{ secrets.PYPI_API_TOKEN }}",
+    }
+    assert {step["run"] for step in uploads} == {
+        "python scripts/upload_python_release.py --repository testpypi dist/*",
+        "python scripts/upload_python_release.py --repository pypi dist/*",
     }
     assert all("steps.channel.outputs.token" not in str(step) for step in publish["steps"])
 

--- a/tests/test_quality_ci_workflow.py
+++ b/tests/test_quality_ci_workflow.py
@@ -242,7 +242,10 @@ def test_rust_dist_and_manual_verifiers_cover_replacement_smoke() -> None:
     assert "$startInfo.UseShellExecute = $false" in windows_installer
     assert "[int]$TimeoutMilliseconds = 35000" in windows_installer
     assert "$process.WaitForExit($TimeoutMilliseconds)" in windows_installer
-    assert "Stdout = [string]$stdoutTask.Result" in windows_installer
+    assert "$stdoutTask.Wait(1000)" in windows_installer
+    assert "$stderrTask.Wait(1000)" in windows_installer
+    assert "Stdout = $stdout" in windows_installer
+    assert "Stderr = $stderr" in windows_installer
 
 
 def test_ci_does_not_carry_retired_source_size_or_one_time_migration_governance() -> None:

--- a/tests/test_upload_python_release.py
+++ b/tests/test_upload_python_release.py
@@ -1,0 +1,42 @@
+from pathlib import Path
+from subprocess import CompletedProcess
+
+from scripts import upload_python_release
+
+
+def test_existing_release_set_is_an_idempotent_success(monkeypatch, tmp_path: Path) -> None:
+    wheel = tmp_path / "cccc_pair-0.4.35rc1-py3-none-any.whl"
+    wheel.touch()
+    monkeypatch.setattr(upload_python_release, "existing_filenames", lambda _repository: {wheel.name})
+    monkeypatch.setattr(
+        upload_python_release.subprocess,
+        "run",
+        lambda *_args, **_kwargs: (_ for _ in ()).throw(AssertionError("upload must be skipped")),
+    )
+
+    assert upload_python_release.upload_missing("testpypi", [wheel]) == 0
+
+
+def test_only_missing_distributions_are_uploaded(monkeypatch, tmp_path: Path) -> None:
+    existing = tmp_path / "cccc_pair-0.4.35rc1-py3-none-any.whl"
+    missing = tmp_path / "cccc_pair-0.4.35rc1-cp314-win_amd64.whl"
+    existing.touch()
+    missing.touch()
+    observed: list[list[str]] = []
+    monkeypatch.setattr(
+        upload_python_release,
+        "existing_filenames",
+        lambda _repository: {existing.name},
+    )
+
+    def run(command: list[str], **_kwargs) -> CompletedProcess:
+        observed.append(command)
+        return CompletedProcess(command, 0)
+
+    monkeypatch.setattr(upload_python_release.subprocess, "run", run)
+
+    assert upload_python_release.upload_missing("testpypi", [existing, missing]) == 0
+    assert len(observed) == 1
+    assert "--skip-existing" in observed[0]
+    assert str(existing) not in observed[0]
+    assert str(missing) in observed[0]

--- a/web/package-lock.json
+++ b/web/package-lock.json
@@ -4651,9 +4651,9 @@
       }
     },
     "node_modules/nanoid": {
-      "version": "3.3.17",
-      "resolved": "https://registry.npmjs.org/nanoid/-/nanoid-3.3.17.tgz",
-      "integrity": "sha512-xQLf0A3HOMlgHq0n247/LRuAOYmB7dXJ/DvAxGvsSBij45XtBSmQycu+F8ODbHwns/XyFZagyL1+J0Offw1E0g==",
+      "version": "3.3.18",
+      "resolved": "https://registry.npmjs.org/nanoid/-/nanoid-3.3.18.tgz",
+      "integrity": "sha512-DTg4MJbGMWkfi6VZFdNt2/caMbQy4Ou+Op/hJQvGEWcnVfoA1QA+xzRKAzw9jD6+GVOOeYr/mIcuDSdug6F6+w==",
       "dev": true,
       "funding": [
         {


### PR DESCRIPTION
## Summary

- prepare the v0.4.35-rc1 release identity, changelog, and release documentation
- restore and harden CLI/daemon lifecycle behavior across supported platforms
- prevent Windows standalone daemon restart from hanging on inherited output pipes
- extend cross-platform CI and release verification coverage

## Validation

- v0.4.35-rc1 standalone release workflow passed on Linux, Windows, Intel macOS, and ARM macOS
- Windows install/reinstall/update/stop executable-release verification passed
- targeted Python workflow tests passed
- release asset packaging checks passed
- public GitHub release assets verified with curl

## Release

- https://github.com/ChesterRa/cccc/releases/tag/v0.4.35-rc1
- https://github.com/ChesterRa/cccc/actions/runs/32359747472