### PR TITLE
fix(codex): 默认关闭托管会话的启动更新检查

### DIFF
--- a/crates/cccc-daemon/src/ops/codex_voice_analyst/launch_command.rs
+++ b/crates/cccc-daemon/src/ops/codex_voice_analyst/launch_command.rs
@@ -23,7 +23,12 @@ pub(super) fn prepare(
     let executable = resolve_runtime_executable(&configured[0], environment)?;
     let (arguments, has_web_search) = codex_global_arguments(&configured[1..])?;
     let model = model_from_arguments(&arguments);
-    let mut remote_tui_prefix = vec![executable.to_string_lossy().into_owned()];
+    // 更新由操作者管理，避免启动菜单把投递的消息当作升级选择；显式参数仍可覆盖默认值。
+    let mut remote_tui_prefix = vec![
+        executable.to_string_lossy().into_owned(),
+        "-c".into(),
+        "check_for_update_on_startup=false".into(),
+    ];
     remote_tui_prefix.extend(arguments);
     if !has_web_search {
         remote_tui_prefix.extend(["-c".into(), "web_search=\"live\"".into()]);

--- a/crates/cccc-daemon/src/ops/codex_voice_analyst/tests/unit.rs
+++ b/crates/cccc-daemon/src/ops/codex_voice_analyst/tests/unit.rs
@@ -35,6 +35,31 @@ fn default_launch_uses_one_effective_prefix_for_app_server_and_remote_tui() {
             .windows(2)
             .any(|pair| pair == ["-c", "web_search=\"live\""])
     );
+    assert_eq!(
+        &prepared.remote_tui_prefix[1..3],
+        ["-c", "check_for_update_on_startup=false"]
+    );
+}
+
+#[test]
+fn startup_update_default_preserves_explicit_overrides() {
+    let executable = std::env::current_exe().expect("test executable");
+    for value in ["true", "false"] {
+        let config = format!("check_for_update_on_startup={value}");
+        for flags in [
+            vec!["-c".to_owned(), config.clone()],
+            vec!["--config".to_owned(), config.clone()],
+            vec![format!("--config={config}")],
+        ] {
+            let mut configured = vec![executable.to_string_lossy().into_owned()];
+            configured.extend(flags.clone());
+            let prepared = launch_command::prepare(&configured, &BTreeMap::new()).expect("command");
+            for command in [&prepared.remote_tui_prefix, &prepared.app_server] {
+                assert_eq!(&command[1..3], ["-c", "check_for_update_on_startup=false"]);
+                assert_eq!(&command[3..3 + flags.len()], flags.as_slice());
+            }
+        }
+    }
 }
 
 #[test]
@@ -56,6 +81,8 @@ fn app_server_launch_matches_the_codex_actor_yolo_policy() {
         prepared.remote_tui_prefix,
         vec![
             executable.to_string_lossy().as_ref(),
+            "-c",
+            "check_for_update_on_startup=false",
             "--search",
             "--profile",
             "voice",
@@ -74,6 +101,8 @@ fn app_server_launch_matches_the_codex_actor_yolo_policy() {
         prepared.app_server,
         vec![
             executable.to_string_lossy().as_ref(),
+            "-c",
+            "check_for_update_on_startup=false",
             "--search",
             "--profile",
             "voice",
@@ -149,6 +178,8 @@ fn app_server_replaces_actor_host_policy_but_preserves_user_model_options() {
         prepared.remote_tui_prefix,
         vec![
             executable.to_string_lossy().as_ref(),
+            "-c",
+            "check_for_update_on_startup=false",
             "--model",
             "gpt-test",
             "-c",

--- a/crates/cccc-runtime/src/command.rs
+++ b/crates/cccc-runtime/src/command.rs
@@ -295,7 +295,7 @@ pub fn default_command(runtime: ActorRuntime) -> Vec<String> {
         ActorRuntime::Claude => "claude --dangerously-skip-permissions",
         ActorRuntime::Cline => "cline --tui --auto-approve true",
         ActorRuntime::Codex => {
-            "codex -c shell_environment_policy.inherit=all --dangerously-bypass-approvals-and-sandbox --search"
+            "codex -c check_for_update_on_startup=false -c shell_environment_policy.inherit=all --dangerously-bypass-approvals-and-sandbox --search"
         }
         ActorRuntime::Deepseek => "dsh-acp-demo",
         ActorRuntime::Copilot => "copilot --allow-all",
@@ -464,6 +464,15 @@ mod tests {
     use super::{deepseek_home, default_command, detect_runtimes};
     use cccc_contracts::ActorRuntime;
     use std::collections::BTreeMap;
+
+    #[test]
+    fn codex_default_disables_startup_update_checks() {
+        assert!(
+            default_command(ActorRuntime::Codex)
+                .windows(2)
+                .any(|pair| pair == ["-c", "check_for_update_on_startup=false"])
+        );
+    }
 
     #[cfg(unix)]
     #[test]

--- a/docs/guide/runtimes.md
+++ b/docs/guide/runtimes.md
@@ -37,7 +37,7 @@ CCCC applies runtime-specific launch defaults for actors it starts. These defaul
 |------------|-----------------|--------------------------------|
 | `claude` | `claude --dangerously-skip-permissions` | Skips Claude Code permission prompts. |
 | `cline` | `cline --tui --auto-approve true` | Opens Cline's interactive TUI and enables tool auto-approval. |
-| `codex` | `codex -c shell_environment_policy.inherit=all --dangerously-bypass-approvals-and-sandbox --search` | Bypasses Codex approvals/sandbox and preserves actor environment inheritance for MCP subprocesses. |
+| `codex` | `codex -c check_for_update_on_startup=false -c shell_environment_policy.inherit=all --dangerously-bypass-approvals-and-sandbox --search` | Bypasses Codex approvals/sandbox and preserves actor environment inheritance for MCP subprocesses. |
 | `deepseek` | CCCC-managed `dsh-acp-demo --config …/cordis.yml` | Official ACP app composition; provider permission requests are rejected rather than implicitly approved. |
 | `copilot` | `copilot --allow-all` | Allows Copilot CLI tool execution without per-action approval. |
 | `cursor` | `cursor-agent --yolo --approve-mcps` | Uses Cursor YOLO mode and approves MCP usage. |
@@ -54,6 +54,8 @@ CCCC applies runtime-specific launch defaults for actors it starts. These defaul
 | `kilo` | `kilo` | Same request-scoped ACP approval policy as OpenCode; no persistent provider approval is written. |
 | `web_model` | N/A | Browser-delivered runtime; local CLI launch flags do not apply. |
 | `custom` | User command | CCCC preserves the user-provided command exactly. |
+
+CCCC 启动的 Codex 默认关闭启动更新检查，避免交互式升级菜单阻塞会话或消费待投递的消息。托管 app-server 与原生终端使用同一默认值，包括自定义可执行路径。CLI 升级仍由操作者通过原安装渠道管理；不修改全局 `config.toml`。需要恢复检查时，可在 Actor 或 Runtime Profile 的命令中显式添加 `-c check_for_update_on_startup=true`。这不解决不兼容版本或失效登录。
 
 ## Setup Commands
 


### PR DESCRIPTION
## 问题

CCCC 托管的 Codex 原生终端可能在启动时显示交互式升级菜单，阻塞正常会话，或把待投递的消息当作升级选项。在由操作者统一管理 CLI 版本的部署中，启动 Actor 不应触发自助升级。

## 最小修改

- Codex 默认命令增加 `-c check_for_update_on_startup=false`。
- app-server 与原生终端的共享启动前缀同样设置该默认值，覆盖自定义 Codex 可执行路径。
- 默认值放在用户参数之前，保留显式 `-c`、`--config` 和 `--config=` 覆盖。
- 不修改全局配置、模型、登录或权限策略，不引入安装/升级服务。

此修复仅处理启动更新检查；不解决不兼容 CLI 版本或失效登录。CLI 仍须由操作者通过原安装渠道升级。

## 验证

- `cargo test --offline --locked -p cccc-pair-runtime --lib`：120 项通过。
- `cargo test --offline --locked -p cccc-pair-daemon --lib ops::codex_voice_analyst::tests::unit`：8 项通过。
- `cargo fmt --all --check` 和 `git diff --check` 通过。
- 测试覆盖默认值、显式 true/false、三种配置参数形式，以及原模型、Profile、搜索和权限参数保持不变。

配置语义参考：https://learn.chatgpt.com/docs/config-file/config-reference
